### PR TITLE
chore(sync): export sync js objects from lib/index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+**/bun.lockb

--- a/sync/gen/web/src/index.ts
+++ b/sync/gen/web/src/index.ts
@@ -1,1 +1,2 @@
-
+export * from "./utxorpc/sync/v1/sync_connect";
+export * from "./utxorpc/sync/v1/sync_pb";

--- a/sync/gen/web/src/utxorpc/sync/v1/sync_pb.ts
+++ b/sync/gen/web/src/utxorpc/sync/v1/sync_pb.ts
@@ -5,7 +5,7 @@
 
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
 import { FieldMask, Message, proto3, protoInt64 } from "@bufbuild/protobuf";
-import { Block } from "@utxorpc-web/cardano-spec/utxorpc/cardano/v1/cardano_pb.js";
+import { Block } from "@utxorpc-web/cardano-spec";
 
 /**
  * Represents a reference to a specific block


### PR DESCRIPTION
This PR allows much cleaner import syntax 

```ts
import { BlockRef, ChainSyncService, FollowTipResponse } from "@utxorpc-web/sync-spec";
```
rather than

```ts
import { ChainSyncService } from "@utxorpc-web/sync-spec/utxorpc/sync/v1/sync_connect.js";
import {
  BlockRef,
  FollowTipResponse,
} from "@utxorpc-web/sync-spec/utxorpc/sync/v1/sync_pb.js";
```

which for some reason also caused `tsc` compiler to sometimes complain about modules not being found.