### PR TITLE
Fix crate name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ cargo install protoc-gen-prost
 ```
 
 ```sh
-cargo install protoc-gen-crate
+cargo install protoc-gen-prost-crate
 ```
 
 ```sh


### PR DESCRIPTION
Fix crate name to `protoc-gen-prost-crate`.

Previous (`protoc-gen-crate`) does not exist.