### PR TITLE
Fix haskell build after move

### DIFF
--- a/.github/workflows/build-haskell.yml
+++ b/.github/workflows/build-haskell.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: codegen
+          path: gen
 
       - name: Setup Haskell
         id: setup-hs

--- a/.github/workflows/build-haskell.yml
+++ b/.github/workflows/build-haskell.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Configure Cabal build
         run: |
-          cd {{ env.HASKELL_ROOT }}
+          cd ${{ env.HASKELL_ROOT }}
           cabal configure --enable-tests --enable-benchmarks --disable-documentation
           cabal build all --dry-run
         # ^ Creates a plan.json file equivalent to a package-lock.json, used for creating a cache key
@@ -55,7 +55,7 @@ jobs:
       - name: Get Package Version
         id: package-version
         run: |
-          cd {{ env.HASKELL_ROOT }}
+          cd ${{ env.HASKELL_ROOT }}
           VERSION=$(sed -nE '/^version:\s*([0-9]\.[0-9]+\.[0-9]+.*)$/s||\1|p' utxorpc.cabal)
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -64,7 +64,7 @@ jobs:
         env:
           version: ${{ steps.package-version.outputs.VERSION }}
         run: |
-          cd {{ env.HASKELL_ROOT }}
+          cd ${{ env.HASKELL_ROOT }}
           cabal build
           cabal sdist
           echo "SDIST-LOCATION=$(pwd)/dist-newstyle/sdist/utxorpc-${{ env.version }}.tar.gz" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-haskell.yml
+++ b/.github/workflows/build-haskell.yml
@@ -6,11 +6,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      HASKELL_ROOT: gen/haskell
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - run: cd gen/haskell
 
       - name: Install protoc
         run: |
@@ -35,6 +35,7 @@ jobs:
 
       - name: Configure Cabal build
         run: |
+          cd {{ env.HASKELL_ROOT }}
           cabal configure --enable-tests --enable-benchmarks --disable-documentation
           cabal build all --dry-run
         # ^ Creates a plan.json file equivalent to a package-lock.json, used for creating a cache key
@@ -43,8 +44,7 @@ jobs:
         uses: actions/cache/restore@v4
         id: cache-cabal-build
         env:
-          key:
-            ${{ runner.os }}-ghc-${{ steps.setup-hs.outputs.ghc-version
+          key: ${{ runner.os }}-ghc-${{ steps.setup-hs.outputs.ghc-version
             }}-cabal-${{ steps.setup-hs.outputs.cabal-version }}
         with:
           path: ${{ steps.setup-hs.outputs.cabal-store }}
@@ -55,6 +55,7 @@ jobs:
       - name: Get Package Version
         id: package-version
         run: |
+          cd {{ env.HASKELL_ROOT }}
           VERSION=$(sed -nE '/^version:\s*([0-9]\.[0-9]+\.[0-9]+.*)$/s||\1|p' utxorpc.cabal)
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
@@ -63,6 +64,7 @@ jobs:
         env:
           version: ${{ steps.package-version.outputs.VERSION }}
         run: |
+          cd {{ env.HASKELL_ROOT }}
           cabal build
           cabal sdist
           echo "SDIST-LOCATION=$(pwd)/dist-newstyle/sdist/utxorpc-${{ env.version }}.tar.gz" >> "$GITHUB_OUTPUT"

--- a/gen/haskell/README.md
+++ b/gen/haskell/README.md
@@ -1,0 +1,3 @@
+# UTxO RPC
+
+This package contains the generated code from [the UTxO RPC specification](https://utxorpc.org/). Codegen was performed using `proto-lens-protoc` and contains `Message` types useful for serde. For more support for implementing a UTxO RPC client or service, see [the SDK](https://www.github.com/utxorpc/haskell-sdk).

--- a/gen/haskell/utxorpc.cabal
+++ b/gen/haskell/utxorpc.cabal
@@ -31,7 +31,7 @@ library
       Proto.Utxorpc.V1alpha.Watch.Watch
       Proto.Utxorpc.V1alpha.Watch.Watch_Fields
   hs-source-dirs:
-      gen/haskell
+      .
   build-depends:
       base >=4.7 && <5
     , proto-lens >= 0.7.1 && < 0.8


### PR DESCRIPTION
1. Fix paths in workflow files after moving to `gen/haskell`.
2. Add a Haskell-specific README to prevent warnings during packaging.

There was a cache miss causing the dependencies to be rebuilt from scratch. I think this is because the previous caches were from a workflow on a different branch causing a different [cache version](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key), but lets check when CI starts running on `main` that the cache is working properly.