### PR TITLE
Update Rust plugins to latest

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -34,22 +34,22 @@ jobs:
       - name: Install Prost from Cargo
         uses: baptiste0928/cargo-install@v2
         with:
-          crate: protoc-gen-prost
+          crate: protoc-gen-prost-0.3.1
 
       - name: Install protoc-gen-prost-crate from Cargo
         uses: baptiste0928/cargo-install@v2
         with:
-          crate: protoc-gen-prost-crate
+          crate: protoc-gen-prost-crate-0.4.0
 
       - name: Install Prost serde from Cargo
         uses: baptiste0928/cargo-install@v2
         with:
-          crate: protoc-gen-prost-serde
+          crate: protoc-gen-prost-serde-0.3.0
 
       - name: Install Tonic from Cargo
         uses: baptiste0928/cargo-install@v2
         with:
-          crate: protoc-gen-tonic
+          crate: protoc-gen-tonic-0.4.0
 
       - name: Setup Haskell
         uses: ./.github/actions/setup-protoc-hololens

--- a/gen/rust/Cargo.toml
+++ b/gen/rust/Cargo.toml
@@ -12,11 +12,11 @@ authors = ["Santiago Carmuega <santiago@carmuega.me>"]
 
 [dependencies]
 bytes = "^1.4"
-pbjson = "^0.5"
-pbjson-types = "^0.5"
-prost = "^0.11"
+pbjson = "^0.6"
+pbjson-types = "^0.6"
+prost = "^0.12"
 serde = "^1.0"
-tonic = "^0.9"
+tonic = "^0.11"
 
 [features]
 default = []


### PR DESCRIPTION
# Purpose
Update Rust plugins to latest versions.

## Possible Breaking Changes
The new plugins include breaking changes. Merging this PR may create breaking changes for the Rust crate. The Rust SDK will also require changes to its dependencies once it depends on code generated by this PR, but I have confirmed that it will build without any source code changes.