### PR TITLE
fix(go): remove requirements as they are generated at build

### DIFF
--- a/gen/go/go.mod
+++ b/gen/go/go.mod
@@ -1,7 +1,3 @@
 module github.com/utxorpc/go-codegen
 
 go 1.20
-
-require google.golang.org/protobuf v1.32.0
-
-require connectrpc.com/connect v1.14.0


### PR DESCRIPTION
This was triggering dependabot while the actual code downstream was using newer versions as updating is part of the CI workflow. Removing the versions here, entirely. This will appease dependabot.