### PR TITLE
refactor: rename Build module into Query

### DIFF
--- a/gen/haskell/utxorpc.cabal
+++ b/gen/haskell/utxorpc.cabal
@@ -24,10 +24,10 @@ extra-source-files:
 
 library
   exposed-modules:
-      Proto.Utxorpc.V1alpha.Build.Build
-      Proto.Utxorpc.V1alpha.Build.Build_Fields
       Proto.Utxorpc.V1alpha.Cardano.Cardano
       Proto.Utxorpc.V1alpha.Cardano.Cardano_Fields
+      Proto.Utxorpc.V1alpha.Query.Query
+      Proto.Utxorpc.V1alpha.Query.Query_Fields
       Proto.Utxorpc.V1alpha.Submit.Submit
       Proto.Utxorpc.V1alpha.Submit.Submit_Fields
       Proto.Utxorpc.V1alpha.Sync.Sync

--- a/gen/rust/src/lib.rs
+++ b/gen/rust/src/lib.rs
@@ -1,17 +1,15 @@
 // @generated
 pub mod utxorpc {
-    pub mod v1 {
-        // @@protoc_insertion_point(attribute:utxorpc.v1.build)
-        pub mod build {
-            include!("utxorpc.v1.build.rs");
-            // @@protoc_insertion_point(utxorpc.v1.build)
-        }
-    }
     pub mod v1alpha {
         // @@protoc_insertion_point(attribute:utxorpc.v1alpha.cardano)
         pub mod cardano {
             include!("utxorpc.v1alpha.cardano.rs");
             // @@protoc_insertion_point(utxorpc.v1alpha.cardano)
+        }
+        // @@protoc_insertion_point(attribute:utxorpc.v1alpha.query)
+        pub mod query {
+            include!("utxorpc.v1alpha.query.rs");
+            // @@protoc_insertion_point(utxorpc.v1alpha.query)
         }
         // @@protoc_insertion_point(attribute:utxorpc.v1alpha.submit)
         pub mod submit {

--- a/proto/utxorpc/v1alpha/query/query.proto
+++ b/proto/utxorpc/v1alpha/query/query.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package utxorpc.v1alpha.build;
+package utxorpc.v1alpha.query;
 
 import "google/protobuf/field_mask.proto";
 import "utxorpc/v1alpha/cardano/cardano.proto";
@@ -75,21 +75,10 @@ message GetUtxoByRefResponse {
   string next_token = 2; // Token for pagination.
 }
 
-// Request to hold UTxOs.
-message HoldUtxoRequest {
-  repeated UtxoRef refs = 1; // List of UTxO references to hold.
-}
-
-// Response containing information about lost UTxOs.
-message HoldUtxoResponse {
-  repeated UtxoRef lost = 1; // List of lost UTxO references.
-}
-
 // Service definition for querying the state of the ledger.
 service LedgerStateService {
   rpc GetChainTip(GetChainTipRequest) returns (GetChainTipResponse); // Get the current chain tip.
   rpc GetChainParam(GetChainParamRequest) returns (GetChainParamResponse); // Get specific chain parameters.
   rpc GetUtxoByAddress(GetUtxoByAddressRequest) returns (GetUtxoByAddressResponse); // Get UTxOs by their associated addresses.
   rpc GetUtxoByRef(GetUtxoByRefRequest) returns (GetUtxoByRefResponse); // Get UTxOs by their references.
-  rpc HoldUtxo(HoldUtxoRequest) returns (stream HoldUtxoResponse); // Hold UTxOs and receive updates about lost UTxOs
 }


### PR DESCRIPTION
Rationale: the original name (given by me) was defined to convey the idea that this module could be used as backend provider for Tx builders (eg: lucid / mesh providers). The reality is that almost all of the requirements involving tx-building are actually data queries and the remaining requirements are already fulfilled by other modules (Submit, Watch).