### PR TITLE
refactor(query): allow chain-specific queries

### DIFF
--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -320,7 +320,7 @@ message MirCert {
 
 // Pattern of an address that can be used to evaluate matching predicates.
 message AddressPattern {
-  bytes byron_address = 1; // The address should match this exact Byron address value.
+  bytes exact_address = 1; // The address should match this exact address value.
   bytes payment_part = 2; // The payment part of the address should match this value.
   bytes delegation_part = 3; // The delegation part of the address should match this value.
 }
@@ -334,7 +334,7 @@ message AssetPattern {
 // Pattern of a tx output that can be used to evaluate matching predicates.
 message TxOutputPattern {
   AddressPattern address = 1; // Match any address in the output that exhibits this pattern.
-  AssetPattern has_asset = 2; // Match any asset in the output that exhibits this pattern.
+  AssetPattern asset = 2; // Match any asset in the output that exhibits this pattern.
 }
 
 // Pattern of a Tx that can be used to evaluate matching predicates.
@@ -342,7 +342,8 @@ message TxPattern {
   TxOutputPattern consumes = 1; // Match any input that exhibits this pattern.
   TxOutputPattern produces = 2; // Match any output that exhibits this pattern.
   AddressPattern has_address = 3; // Match any address (inputs, outputs, collateral, etc) that exhibits this pattern.
-  AssetPattern has_asset = 4; // Match any asset that exhibits this pattern.
+  AssetPattern moves_asset = 4; // Match any asset that exhibits this pattern.
+  AssetPattern mints_asset = 5; // Match any tx that either mint or burn the the asset pattern.
 }
 
 // PARAMS

--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -323,58 +323,29 @@ message AddressPattern {
   bytes byron_address = 1; // The address should match this exact Byron address value.
   bytes payment_part = 2; // The payment part of the address should match this value.
   bytes delegation_part = 3; // The delegation part of the address should match this value.
-  bool payment_is_script = 4; // The payment part of the address is a script.
-  bool delegation_is_script = 5; // The delegation part of the address is a script.
-}
-
-// Pattern of a coin value that can be used to evaluate matching predicates.
-message CoinPattern {
-  int64 exact_value = 1; // The value should be exactly this amount
-  int64 upper_bound = 2; // The value should be at most this amount (inclusive)
-  int64 lower_bound = 3; // The value should be at leaste this amount (inclusive)
 }
 
 // Pattern of a native asset that can be used to evaluate matching predicates.
 message AssetPattern {
   bytes policy_id = 1; // The asset should belong to this policy id
   bytes asset_name = 2; // The asset should present this name
-  CoinPattern coin_pattern = 3; // The amount of the asset should match this pattern
-}
-
-// Pattern of multiple native asset that can be used to evaluate matching predicates.
-message MultiAssetPattern {
-  CoinPattern lovalace_pattern = 1; // The multi-asset should exhibit this lovelace pattern
-  repeated AssetPattern asset_patterns = 2; // The multi-asset should exhibit this asset patterns simultanously.
 }
 
 // Pattern of a tx output that can be used to evaluate matching predicates.
-message OutputPattern {
-  AddressPattern any_address = 1; // Match any address in the output that exhibits this pattern.
-  MultiAssetPattern any_asset = 2; // Match any asset in the output that exhibits this pattern.
-  CoinPattern lovelace_pattern = 3; // Match the Lovelace amount in the output that exhibits this pattern.
-}
-
-// Pattern of a tx input that can be used to evaluate matching predicates.
-message InputPattern {
-  AddressPattern address = 1; // Match the input with an address that exhibits this pattern.
-  MultiAssetPattern any_asset = 2; // Match the input with any asset that exhibits this pattern.
-  CoinPattern lovelace_pattern = 3; // Match the Lovelace amount in the input that exhibits this pattern.
-  RedeemerPurpose purpose = 4; // Math the input that has this redeemer purpose.
-  DatumPattern redeemer = 5; // Match the input with a redeemer exhibits this pattern.
-}
-
-// Pattern of an datum that can be used to evaluate matching predicates.
-message DatumPattern {
-  bytes hash = 1; // Math the datum that exhibits this hash value.
+message TxOutputPattern {
+  AddressPattern address = 1; // Match any address in the output that exhibits this pattern.
+  AssetPattern has_asset = 2; // Match any asset in the output that exhibits this pattern.
 }
 
 // Pattern of a Tx that can be used to evaluate matching predicates.
 message TxPattern {
-  oneof tx_pattern {
-    InputPattern any_input = 1; // Match any input that exhibits this pattern.
-    OutputPattern any_output = 2; // Match any output that exhibits this pattern.
-    AddressPattern any_address = 3; // Match any address (inputs, outputs, collateral, etc) that exhibits this pattern.
-    MultiAssetPattern any_asset = 4; // Match any asset that exhibits this pattern.
-    DatumPattern any_datum = 5; // Match any datum that exhibits this pattern.
-  }
+  TxOutputPattern consumes = 1; // Match any input that exhibits this pattern.
+  TxOutputPattern produces = 2; // Match any output that exhibits this pattern.
+  AddressPattern has_address = 3; // Match any address (inputs, outputs, collateral, etc) that exhibits this pattern.
+  AssetPattern has_asset = 4; // Match any asset that exhibits this pattern.
 }
+
+// PARAMS
+// ======
+
+message Params {}

--- a/proto/utxorpc/v1alpha/query/query.proto
+++ b/proto/utxorpc/v1alpha/query/query.proto
@@ -14,71 +14,68 @@ message ChainPoint {
   bytes hash = 3; // Block hash.
 }
 
-// Request to get the current chain tip.
-message GetChainTipRequest {}
-
-// Response containing the current chain tip.
-message GetChainTipResponse {
-  ChainPoint tip = 1; // Current chain tip.
+// Request to get the chain parameters
+message ReadParamsRequest {
+  google.protobuf.FieldMask field_mask = 1; // Field mask to selectively return fields in the parsed response.
 }
 
-// Request to get specific chain parameters.
-message GetChainParamRequest {
-  repeated string param = 1; // List of requested parameters.
+// An evenlope that holds parameter data from any of the compatible chains
+message AnyChainParams {
+  oneof params {
+    utxorpc.v1alpha.cardano.Params cardano = 1; // Cardano parameters
+  }
 }
 
-// Represents a key-value pair for a chain parameter.
-message ChainParam {
-  string key = 1; // Parameter key.
-  bytes value = 2; // Parameter value.
+// Response containing the chain parameters
+message ReadParamsResponse {
+  AnyChainParams values = 1; // The value of the parameters.
+  ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
 }
 
-// Response containing the requested chain parameters.
-message GetChainParamResponse {
-  repeated ChainParam param = 1; // List of requested chain parameters.
+// An evenlope that holds an UTxO patterns from any of compatible chains
+message AnyUtxoPattern {
+  oneof utxo_pattern {
+    utxorpc.v1alpha.cardano.TxOutputPattern cardano = 1;
+  }
 }
 
-// Request to get UTxOs by their associated addresses.
-message GetUtxoByAddressRequest {
-  repeated bytes address = 1; // List of addresses to query.
-  ChainPoint acquire_point = 2; // Point in the chain to query from.
+// Represents a simple utxo predicate that can composed to create more complext ones
+message UtxoPredicate {
+  AnyUtxoPattern match = 1; // Predicate is true if tx exhibits pattern.
+  repeated UtxoPredicate not = 2; // Predicate is true if tx doesn't exhibit pattern.
+  repeated UtxoPredicate all_of = 3; // Predicate is true if utxo exhibits all of the patterns.
+  repeated UtxoPredicate any_of = 4; // Predicate is true if utxo exhibits any of the patterns.
+}
+
+// Request to get UTxOs by chain-specific criteria.
+message ReadUtxosRequest {
+  UtxoPredicate predicate = 1; // A predicate to filter relevant utxos.
+  bool include_native = 3; // Flag to include the raw bytes in their native representation.
+  bool include_parsed = 4; // Flag to parse the result vs using native bytes from the chain.
+  google.protobuf.FieldMask field_mask = 7; // Field mask to selectively return fields in the parsed response.
 }
 
 // An evenlope that holds an UTxO from any of compatible chains
-message AnyChainUtxo {
-  oneof chain {
-    utxorpc.v1alpha.cardano.TxOutput cardano = 1;
+message AnyUtxoData {
+  bytes native_bytes = 1; // An opaque bytestring corresponding to native representation in the source chain.
+  oneof parsed_state {
+    utxorpc.v1alpha.cardano.TxOutput cardano = 2; // A cardano UTxO
   }
 }
 
 // Response containing the UTxOs associated with the requested addresses.
-message GetUtxoByAddressResponse {
-  repeated AnyChainUtxo items = 1; // List of UTxOs.
-  string next_token = 2; // Token for pagination.
+message ReadUtxosResponse {
+  repeated AnyUtxoData items = 1; // List of UTxOs.
+  ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
 }
 
-// Represents a reference to a UTxO.
-message UtxoRef {
-  bytes hash = 1; // Transaction hash.
-  uint32 index = 2; // Output index.
-}
+// Service definition for querying the state of the chain.
+service QueryService {
+  rpc ReadParams(ReadParamsRequest) returns (ReadParamsResponse); // Get overall chain state.
+  rpc ReadUtxos(ReadUtxosRequest) returns (ReadUtxosResponse); // Read a slice of the utxo set
+  rpc StreamUtxos(ReadUtxosRequest) returns (stream ReadUtxosResponse); // Stream all available utxos
 
-// Request to get UTxOs by their references.
-message GetUtxoByRefRequest {
-  repeated UtxoRef ref = 1; // List of UTxO references to query.
-  ChainPoint acquire_point = 2; // Point in the chain to query from.
-}
-
-// Response containing the UTxOs associated with the requested references.
-message GetUtxoByRefResponse {
-  repeated AnyChainUtxo items = 1; // List of UTxOs.
-  string next_token = 2; // Token for pagination.
-}
-
-// Service definition for querying the state of the ledger.
-service LedgerStateService {
-  rpc GetChainTip(GetChainTipRequest) returns (GetChainTipResponse); // Get the current chain tip.
-  rpc GetChainParam(GetChainParamRequest) returns (GetChainParamResponse); // Get specific chain parameters.
-  rpc GetUtxoByAddress(GetUtxoByAddressRequest) returns (GetUtxoByAddressResponse); // Get UTxOs by their associated addresses.
-  rpc GetUtxoByRef(GetUtxoByRefRequest) returns (GetUtxoByRefResponse); // Get UTxOs by their references.
+  // TODO: decide if we want to expand the scope
+  // rpc ReadAccount(ReadAccountRequest) returns (ReadAccountReponse); // Get state of a particular account
+  // rpc ReadTxs(GetTxRequest) returns (GetTxResponse); // Get Txs by by chain-specific criteria.
 }

--- a/proto/utxorpc/v1alpha/query/query.proto
+++ b/proto/utxorpc/v1alpha/query/query.proto
@@ -10,8 +10,13 @@ import "utxorpc/v1alpha/cardano/cardano.proto";
 // Represents a specific point in the blockchain.
 message ChainPoint {
   uint64 slot = 1; // Slot number.
-  uint64 height = 2; // Block height.
-  bytes hash = 3; // Block hash.
+  bytes hash = 2; // Block hash.
+}
+
+// Represents a reference to a transaction output
+message TxoRef {
+  bytes hash = 1; // Tx hash.
+  uint32 index = 2; // Output index.
 }
 
 // Request to get the chain parameters
@@ -47,20 +52,18 @@ message UtxoPredicate {
   repeated UtxoPredicate any_of = 4; // Predicate is true if utxo exhibits any of the patterns.
 }
 
-// Request to get UTxOs by chain-specific criteria.
-message ReadUtxosRequest {
-  UtxoPredicate predicate = 1; // A predicate to filter relevant utxos.
-  bool include_native = 3; // Flag to include the raw bytes in their native representation.
-  bool include_parsed = 4; // Flag to parse the result vs using native bytes from the chain.
-  google.protobuf.FieldMask field_mask = 7; // Field mask to selectively return fields in the parsed response.
-}
-
 // An evenlope that holds an UTxO from any of compatible chains
 message AnyUtxoData {
-  bytes native_bytes = 1; // An opaque bytestring corresponding to native representation in the source chain.
+  TxoRef txo_ref = 1; // Hash of the previous transaction.
+  bytes native_bytes = 2; // An opaque bytestring corresponding to native representation in the source chain.
   oneof parsed_state {
-    utxorpc.v1alpha.cardano.TxOutput cardano = 2; // A cardano UTxO
+    utxorpc.v1alpha.cardano.TxOutput cardano = 3; // A cardano UTxO
   }
+}
+
+// Request to get specific UTxOs
+message ReadUtxosRequest {
+  repeated TxoRef keys = 1; // List of keys UTxOs.
 }
 
 // Response containing the UTxOs associated with the requested addresses.
@@ -69,10 +72,22 @@ message ReadUtxosResponse {
   ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
 }
 
+// Reques to search for UTxO based on a pattern.
+message SearchUtxosRequest {
+  UtxoPredicate predicate = 1; // Pattern to match UTxOs by.
+}
+
+// Response containing the UTxOs that match the requested addresses.
+message SearchUtxosResponse {
+  repeated AnyUtxoData items = 1; // List of UTxOs.
+  ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
+}
+
 // Service definition for querying the state of the chain.
 service QueryService {
   rpc ReadParams(ReadParamsRequest) returns (ReadParamsResponse); // Get overall chain state.
-  rpc ReadUtxos(ReadUtxosRequest) returns (ReadUtxosResponse); // Read a slice of the utxo set
+  rpc ReadUtxos(ReadUtxosRequest) returns (ReadUtxosResponse); // Read specific UTxOs by reference.
+  rpc SearchUtxos(SearchUtxosRequest) returns (SearchUtxosResponse); // Search for UTxO based on a pattern.
   rpc StreamUtxos(ReadUtxosRequest) returns (stream ReadUtxosResponse); // Stream all available utxos
 
   // TODO: decide if we want to expand the scope


### PR DESCRIPTION
I'm proposing a new approach for defining queries where the pattern matching criteria is chain-specific instead of generic. This enables more expressive filters.