### PR TITLE
fix: submit consistent tx argument naming

### DIFF
--- a/proto/utxorpc/v1alpha/submit/submit.proto
+++ b/proto/utxorpc/v1alpha/submit/submit.proto
@@ -38,7 +38,7 @@ message TxInMempool {
 
 // Request to check the status of submitted transactions.
 message ReadMempoolRequest {
-  repeated TxInMempool txs = 1; // List of transaction currently on the mempool.
+  repeated TxInMempool tx = 1; // List of transaction currently on the mempool.
 }
 
 // Response containing the stage of the submitted transactions.


### PR DESCRIPTION
This makes the name of the message and generated function names consistent within the module.