### PR TITLE
fix: Improve haskell spec metadata and publish Haddocks in CI

### DIFF
--- a/.github/actions/publish-haskell/action.yml
+++ b/.github/actions/publish-haskell/action.yml
@@ -78,6 +78,11 @@ runs:
         name: haskell-${{ env.version }}
         path: ${{ env.location }}
 
+    - name: Generate Haddocks
+      shell: bash
+      working-directory: codegen/haskell
+      run: stack haddock --haddock-for-hackage
+
     - name: Upload candidate to Hackage
       if: inputs.mode == 'dry-run'
       shell: bash
@@ -85,6 +90,7 @@ runs:
       run: |
         export HACKAGE_KEY=${{ inputs.registry-token }}
         stack upload --candidate --test-tarball .
+        stack upload --candidate -d .
 
     - name: Upload to Hackage
       if: inputs.mode == 'release' && startsWith(github.ref, 'refs/tags/v')
@@ -93,6 +99,7 @@ runs:
       run: |
         export HACKAGE_KEY=${{ inputs.registry-token }}
         stack upload --test-tarball .
+        stack upload -d .
 
     - name: Cache Stack
       if: steps.restore-stack.outputs.cache-hit != 'true'

--- a/gen/docs/docs.md
+++ b/gen/docs/docs.md
@@ -15,7 +15,6 @@
     - [Certificate](#utxorpc-v1alpha-cardano-Certificate)
     - [Collateral](#utxorpc-v1alpha-cardano-Collateral)
     - [Constr](#utxorpc-v1alpha-cardano-Constr)
-    - [DatumPattern](#utxorpc-v1alpha-cardano-DatumPattern)
     - [GenesisKeyDelegationCert](#utxorpc-v1alpha-cardano-GenesisKeyDelegationCert)
     - [Metadata](#utxorpc-v1alpha-cardano-Metadata)
     - [Metadatum](#utxorpc-v1alpha-cardano-Metadatum)
@@ -27,7 +26,7 @@
     - [Multiasset](#utxorpc-v1alpha-cardano-Multiasset)
     - [NativeScript](#utxorpc-v1alpha-cardano-NativeScript)
     - [NativeScriptList](#utxorpc-v1alpha-cardano-NativeScriptList)
-    - [OutputPattern](#utxorpc-v1alpha-cardano-OutputPattern)
+    - [Params](#utxorpc-v1alpha-cardano-Params)
     - [PlutusData](#utxorpc-v1alpha-cardano-PlutusData)
     - [PlutusDataArray](#utxorpc-v1alpha-cardano-PlutusDataArray)
     - [PlutusDataMap](#utxorpc-v1alpha-cardano-PlutusDataMap)
@@ -45,6 +44,7 @@
     - [Tx](#utxorpc-v1alpha-cardano-Tx)
     - [TxInput](#utxorpc-v1alpha-cardano-TxInput)
     - [TxOutput](#utxorpc-v1alpha-cardano-TxOutput)
+    - [TxOutputPattern](#utxorpc-v1alpha-cardano-TxOutputPattern)
     - [TxPattern](#utxorpc-v1alpha-cardano-TxPattern)
     - [TxValidity](#utxorpc-v1alpha-cardano-TxValidity)
     - [VKeyWitness](#utxorpc-v1alpha-cardano-VKeyWitness)
@@ -54,23 +54,21 @@
     - [MirSource](#utxorpc-v1alpha-cardano-MirSource)
     - [RedeemerPurpose](#utxorpc-v1alpha-cardano-RedeemerPurpose)
   
-- [utxorpc/v1alpha/build/build.proto](#utxorpc_v1alpha_build_build-proto)
-    - [AnyChainUtxo](#utxorpc-v1-build-AnyChainUtxo)
-    - [ChainParam](#utxorpc-v1-build-ChainParam)
-    - [ChainPoint](#utxorpc-v1-build-ChainPoint)
-    - [GetChainParamRequest](#utxorpc-v1-build-GetChainParamRequest)
-    - [GetChainParamResponse](#utxorpc-v1-build-GetChainParamResponse)
-    - [GetChainTipRequest](#utxorpc-v1-build-GetChainTipRequest)
-    - [GetChainTipResponse](#utxorpc-v1-build-GetChainTipResponse)
-    - [GetUtxoByAddressRequest](#utxorpc-v1-build-GetUtxoByAddressRequest)
-    - [GetUtxoByAddressResponse](#utxorpc-v1-build-GetUtxoByAddressResponse)
-    - [GetUtxoByRefRequest](#utxorpc-v1-build-GetUtxoByRefRequest)
-    - [GetUtxoByRefResponse](#utxorpc-v1-build-GetUtxoByRefResponse)
-    - [HoldUtxoRequest](#utxorpc-v1-build-HoldUtxoRequest)
-    - [HoldUtxoResponse](#utxorpc-v1-build-HoldUtxoResponse)
-    - [UtxoRef](#utxorpc-v1-build-UtxoRef)
+- [utxorpc/v1alpha/query/query.proto](#utxorpc_v1alpha_query_query-proto)
+    - [AnyChainParams](#utxorpc-v1alpha-query-AnyChainParams)
+    - [AnyUtxoData](#utxorpc-v1alpha-query-AnyUtxoData)
+    - [AnyUtxoPattern](#utxorpc-v1alpha-query-AnyUtxoPattern)
+    - [ChainPoint](#utxorpc-v1alpha-query-ChainPoint)
+    - [ReadParamsRequest](#utxorpc-v1alpha-query-ReadParamsRequest)
+    - [ReadParamsResponse](#utxorpc-v1alpha-query-ReadParamsResponse)
+    - [ReadUtxosRequest](#utxorpc-v1alpha-query-ReadUtxosRequest)
+    - [ReadUtxosResponse](#utxorpc-v1alpha-query-ReadUtxosResponse)
+    - [SearchUtxosRequest](#utxorpc-v1alpha-query-SearchUtxosRequest)
+    - [SearchUtxosResponse](#utxorpc-v1alpha-query-SearchUtxosResponse)
+    - [TxoRef](#utxorpc-v1alpha-query-TxoRef)
+    - [UtxoPredicate](#utxorpc-v1alpha-query-UtxoPredicate)
   
-    - [LedgerStateService](#utxorpc-v1-build-LedgerStateService)
+    - [QueryService](#utxorpc-v1alpha-query-QueryService)
   
 - [utxorpc/v1alpha/submit/submit.proto](#utxorpc_v1alpha_submit_submit-proto)
     - [AnyChainTx](#utxorpc-v1alpha-submit-AnyChainTx)
@@ -130,11 +128,9 @@ Pattern of an address that can be used to evaluate matching predicates.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| byron_address | [bytes](#bytes) |  |  |
-| payment_part | [bytes](#bytes) |  |  |
-| delegation_part | [bytes](#bytes) |  |  |
-| payment_is_script | [bool](#bool) |  |  |
-| delegation_is_script | [bool](#bool) |  |  |
+| exact_address | [bytes](#bytes) |  | The address should match this exact address value. |
+| payment_part | [bytes](#bytes) |  | The payment part of the address should match this value. |
+| delegation_part | [bytes](#bytes) |  | The delegation part of the address should match this value. |
 
 
 
@@ -163,7 +159,11 @@ Represents a custom asset in the Cardano blockchain.
 ### AssetPattern
 Pattern of a native asset that can be used to evaluate matching predicates.
 
-TBD
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| policy_id | [bytes](#bytes) |  | The asset should belong to this policy id |
+| asset_name | [bytes](#bytes) |  | The asset should present this name |
 
 
 
@@ -244,6 +244,7 @@ Contains the header information for a block.
 | ----- | ---- | ----- | ----------- |
 | slot | [uint64](#uint64) |  | Slot number. |
 | hash | [bytes](#bytes) |  | Block hash. |
+| height | [uint64](#uint64) |  | Block height. |
 
 
 
@@ -299,18 +300,6 @@ Represents a constructor for Plutus data in Cardano.
 | tag | [uint32](#uint32) |  |  |
 | any_constructor | [uint64](#uint64) |  |  |
 | fields | [PlutusData](#utxorpc-v1alpha-cardano-PlutusData) | repeated |  |
-
-
-
-
-
-
-<a name="utxorpc-v1alpha-cardano-DatumPattern"></a>
-
-### DatumPattern
-Pattern of an datum that can be used to evaluate matching predicates.
-
-TBD
 
 
 
@@ -499,12 +488,10 @@ Represents a list of native scripts.
 
 
 
-<a name="utxorpc-v1alpha-cardano-OutputPattern"></a>
+<a name="utxorpc-v1alpha-cardano-Params"></a>
 
-### OutputPattern
-Pattern of a tx output that can be used to evaluate matching predicates.
+### Params
 
-TBD
 
 
 
@@ -766,6 +753,7 @@ Represents a transaction in the Cardano blockchain.
 | validity | [TxValidity](#utxorpc-v1alpha-cardano-TxValidity) |  | Validity interval of the transaction |
 | successful | [bool](#bool) |  | Flag indicating whether the transaction was successful |
 | auxiliary | [AuxData](#utxorpc-v1alpha-cardano-AuxData) |  | Auxiliary data not directly tied to the validation process |
+| hash | [bytes](#bytes) |  | Hash of the transaction that serves as main identifier |
 
 
 
@@ -810,6 +798,22 @@ Represents a transaction output in the Cardano blockchain.
 
 
 
+<a name="utxorpc-v1alpha-cardano-TxOutputPattern"></a>
+
+### TxOutputPattern
+Pattern of a tx output that can be used to evaluate matching predicates.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| address | [AddressPattern](#utxorpc-v1alpha-cardano-AddressPattern) |  | Match any address in the output that exhibits this pattern. |
+| asset | [AssetPattern](#utxorpc-v1alpha-cardano-AssetPattern) |  | Match any asset in the output that exhibits this pattern. |
+
+
+
+
+
+
 <a name="utxorpc-v1alpha-cardano-TxPattern"></a>
 
 ### TxPattern
@@ -818,10 +822,11 @@ Pattern of a Tx that can be used to evaluate matching predicates.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| any_output | [OutputPattern](#utxorpc-v1alpha-cardano-OutputPattern) |  | Match any output that exhibits this pattern. |
-| any_address | [AddressPattern](#utxorpc-v1alpha-cardano-AddressPattern) |  | Match any address (inputs, outputs, collateral, etc) that exhibits this pattern. |
-| any_asset | [AssetPattern](#utxorpc-v1alpha-cardano-AssetPattern) |  | Match any asset that exhibits this pattern. |
-| any_datum | [DatumPattern](#utxorpc-v1alpha-cardano-DatumPattern) |  | Match any datum that exhibits this pattern. |
+| consumes | [TxOutputPattern](#utxorpc-v1alpha-cardano-TxOutputPattern) |  | Match any input that exhibits this pattern. |
+| produces | [TxOutputPattern](#utxorpc-v1alpha-cardano-TxOutputPattern) |  | Match any output that exhibits this pattern. |
+| has_address | [AddressPattern](#utxorpc-v1alpha-cardano-AddressPattern) |  | Match any address (inputs, outputs, collateral, etc) that exhibits this pattern. |
+| moves_asset | [AssetPattern](#utxorpc-v1alpha-cardano-AssetPattern) |  | Match any asset that exhibits this pattern. |
+| mints_asset | [AssetPattern](#utxorpc-v1alpha-cardano-AssetPattern) |  | Match any tx that either mint or burn the the asset pattern. |
 
 
 
@@ -930,45 +935,61 @@ Purpose of the redeemer in a transaction.
 
 
 
-<a name="utxorpc_v1alpha_build_build-proto"></a>
+<a name="utxorpc_v1alpha_query_query-proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
-## utxorpc/v1alpha/build/build.proto
+## utxorpc/v1alpha/query/query.proto
 
 
 
-<a name="utxorpc-v1-build-AnyChainUtxo"></a>
+<a name="utxorpc-v1alpha-query-AnyChainParams"></a>
 
-### AnyChainUtxo
+### AnyChainParams
+An evenlope that holds parameter data from any of the compatible chains
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| cardano | [utxorpc.v1alpha.cardano.Params](#utxorpc-v1alpha-cardano-Params) |  | Cardano parameters |
+
+
+
+
+
+
+<a name="utxorpc-v1alpha-query-AnyUtxoData"></a>
+
+### AnyUtxoData
 An evenlope that holds an UTxO from any of compatible chains
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| cardano | [utxorpc.v1alpha.cardano.TxOutput](#utxorpc-v1alpha-cardano-TxOutput) |  |  |
+| txo_ref | [TxoRef](#utxorpc-v1alpha-query-TxoRef) |  | Hash of the previous transaction. |
+| native_bytes | [bytes](#bytes) |  | An opaque bytestring corresponding to native representation in the source chain. |
+| cardano | [utxorpc.v1alpha.cardano.TxOutput](#utxorpc-v1alpha-cardano-TxOutput) |  | A cardano UTxO |
 
 
 
 
 
 
-<a name="utxorpc-v1-build-ChainParam"></a>
+<a name="utxorpc-v1alpha-query-AnyUtxoPattern"></a>
 
-### ChainParam
-Represents a key-value pair for a chain parameter.
+### AnyUtxoPattern
+An evenlope that holds an UTxO patterns from any of compatible chains
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| key | [string](#string) |  | Parameter key. |
-| value | [bytes](#bytes) |  | Parameter value. |
+| cardano | [utxorpc.v1alpha.cardano.TxOutputPattern](#utxorpc-v1alpha-cardano-TxOutputPattern) |  |  |
 
 
 
 
 
 
-<a name="utxorpc-v1-build-ChainPoint"></a>
+<a name="utxorpc-v1alpha-query-ChainPoint"></a>
 
 ### ChainPoint
 Represents a specific point in the blockchain.
@@ -977,7 +998,6 @@ Represents a specific point in the blockchain.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | slot | [uint64](#uint64) |  | Slot number. |
-| height | [uint64](#uint64) |  | Block height. |
 | hash | [bytes](#bytes) |  | Block hash. |
 
 
@@ -985,189 +1005,150 @@ Represents a specific point in the blockchain.
 
 
 
-<a name="utxorpc-v1-build-GetChainParamRequest"></a>
+<a name="utxorpc-v1alpha-query-ReadParamsRequest"></a>
 
-### GetChainParamRequest
-Request to get specific chain parameters.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| param | [string](#string) | repeated | List of requested parameters. |
-
-
-
-
-
-
-<a name="utxorpc-v1-build-GetChainParamResponse"></a>
-
-### GetChainParamResponse
-Response containing the requested chain parameters.
+### ReadParamsRequest
+Request to get the chain parameters
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| param | [ChainParam](#utxorpc-v1-build-ChainParam) | repeated | List of requested chain parameters. |
+| field_mask | [google.protobuf.FieldMask](#google-protobuf-FieldMask) |  | Field mask to selectively return fields in the parsed response. |
 
 
 
 
 
 
-<a name="utxorpc-v1-build-GetChainTipRequest"></a>
+<a name="utxorpc-v1alpha-query-ReadParamsResponse"></a>
 
-### GetChainTipRequest
-Request to get the current chain tip.
-
-
-
-
-
-
-<a name="utxorpc-v1-build-GetChainTipResponse"></a>
-
-### GetChainTipResponse
-Response containing the current chain tip.
+### ReadParamsResponse
+Response containing the chain parameters
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| tip | [ChainPoint](#utxorpc-v1-build-ChainPoint) |  | Current chain tip. |
+| values | [AnyChainParams](#utxorpc-v1alpha-query-AnyChainParams) |  | The value of the parameters. |
+| ledger_tip | [ChainPoint](#utxorpc-v1alpha-query-ChainPoint) |  | The chain point that represent the ledger current position. |
 
 
 
 
 
 
-<a name="utxorpc-v1-build-GetUtxoByAddressRequest"></a>
+<a name="utxorpc-v1alpha-query-ReadUtxosRequest"></a>
 
-### GetUtxoByAddressRequest
-Request to get UTxOs by their associated addresses.
+### ReadUtxosRequest
+Request to get specific UTxOs
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| address | [bytes](#bytes) | repeated | List of addresses to query. |
-| acquire_point | [ChainPoint](#utxorpc-v1-build-ChainPoint) |  | Point in the chain to query from. |
+| keys | [TxoRef](#utxorpc-v1alpha-query-TxoRef) | repeated | List of keys UTxOs. |
 
 
 
 
 
 
-<a name="utxorpc-v1-build-GetUtxoByAddressResponse"></a>
+<a name="utxorpc-v1alpha-query-ReadUtxosResponse"></a>
 
-### GetUtxoByAddressResponse
+### ReadUtxosResponse
 Response containing the UTxOs associated with the requested addresses.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| items | [AnyChainUtxo](#utxorpc-v1-build-AnyChainUtxo) | repeated | List of UTxOs. |
-| next_token | [string](#string) |  | Token for pagination. |
+| items | [AnyUtxoData](#utxorpc-v1alpha-query-AnyUtxoData) | repeated | List of UTxOs. |
+| ledger_tip | [ChainPoint](#utxorpc-v1alpha-query-ChainPoint) |  | The chain point that represent the ledger current position. |
 
 
 
 
 
 
-<a name="utxorpc-v1-build-GetUtxoByRefRequest"></a>
+<a name="utxorpc-v1alpha-query-SearchUtxosRequest"></a>
 
-### GetUtxoByRefRequest
-Request to get UTxOs by their references.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| ref | [UtxoRef](#utxorpc-v1-build-UtxoRef) | repeated | List of UTxO references to query. |
-| acquire_point | [ChainPoint](#utxorpc-v1-build-ChainPoint) |  | Point in the chain to query from. |
-
-
-
-
-
-
-<a name="utxorpc-v1-build-GetUtxoByRefResponse"></a>
-
-### GetUtxoByRefResponse
-Response containing the UTxOs associated with the requested references.
+### SearchUtxosRequest
+Reques to search for UTxO based on a pattern.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| items | [AnyChainUtxo](#utxorpc-v1-build-AnyChainUtxo) | repeated | List of UTxOs. |
-| next_token | [string](#string) |  | Token for pagination. |
+| predicate | [UtxoPredicate](#utxorpc-v1alpha-query-UtxoPredicate) |  | Pattern to match UTxOs by. |
 
 
 
 
 
 
-<a name="utxorpc-v1-build-HoldUtxoRequest"></a>
+<a name="utxorpc-v1alpha-query-SearchUtxosResponse"></a>
 
-### HoldUtxoRequest
-Request to hold UTxOs.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| refs | [UtxoRef](#utxorpc-v1-build-UtxoRef) | repeated | List of UTxO references to hold. |
-
-
-
-
-
-
-<a name="utxorpc-v1-build-HoldUtxoResponse"></a>
-
-### HoldUtxoResponse
-Response containing information about lost UTxOs.
+### SearchUtxosResponse
+Response containing the UTxOs that match the requested addresses.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| lost | [UtxoRef](#utxorpc-v1-build-UtxoRef) | repeated | List of lost UTxO references. |
+| items | [AnyUtxoData](#utxorpc-v1alpha-query-AnyUtxoData) | repeated | List of UTxOs. |
+| ledger_tip | [ChainPoint](#utxorpc-v1alpha-query-ChainPoint) |  | The chain point that represent the ledger current position. |
 
 
 
 
 
 
-<a name="utxorpc-v1-build-UtxoRef"></a>
+<a name="utxorpc-v1alpha-query-TxoRef"></a>
 
-### UtxoRef
-Represents a reference to a UTxO.
+### TxoRef
+Represents a reference to a transaction output
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| hash | [bytes](#bytes) |  | Transaction hash. |
+| hash | [bytes](#bytes) |  | Tx hash. |
 | index | [uint32](#uint32) |  | Output index. |
 
 
 
 
 
- 
+
+<a name="utxorpc-v1alpha-query-UtxoPredicate"></a>
+
+### UtxoPredicate
+Represents a simple utxo predicate that can composed to create more complex ones
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| match | [AnyUtxoPattern](#utxorpc-v1alpha-query-AnyUtxoPattern) |  | Predicate is true if tx exhibits pattern. |
+| not | [UtxoPredicate](#utxorpc-v1alpha-query-UtxoPredicate) | repeated | Predicate is true if tx doesn&#39;t exhibit pattern. |
+| all_of | [UtxoPredicate](#utxorpc-v1alpha-query-UtxoPredicate) | repeated | Predicate is true if utxo exhibits all of the patterns. |
+| any_of | [UtxoPredicate](#utxorpc-v1alpha-query-UtxoPredicate) | repeated | Predicate is true if utxo exhibits any of the patterns. |
+
+
+
+
 
  
 
  
 
+ 
 
-<a name="utxorpc-v1-build-LedgerStateService"></a>
 
-### LedgerStateService
-Service definition for querying the state of the ledger.
+<a name="utxorpc-v1alpha-query-QueryService"></a>
+
+### QueryService
+Service definition for querying the state of the chain.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GetChainTip | [GetChainTipRequest](#utxorpc-v1-build-GetChainTipRequest) | [GetChainTipResponse](#utxorpc-v1-build-GetChainTipResponse) | Get the current chain tip. |
-| GetChainParam | [GetChainParamRequest](#utxorpc-v1-build-GetChainParamRequest) | [GetChainParamResponse](#utxorpc-v1-build-GetChainParamResponse) | Get specific chain parameters. |
-| GetUtxoByAddress | [GetUtxoByAddressRequest](#utxorpc-v1-build-GetUtxoByAddressRequest) | [GetUtxoByAddressResponse](#utxorpc-v1-build-GetUtxoByAddressResponse) | Get UTxOs by their associated addresses. |
-| GetUtxoByRef | [GetUtxoByRefRequest](#utxorpc-v1-build-GetUtxoByRefRequest) | [GetUtxoByRefResponse](#utxorpc-v1-build-GetUtxoByRefResponse) | Get UTxOs by their references. |
-| HoldUtxo | [HoldUtxoRequest](#utxorpc-v1-build-HoldUtxoRequest) | [HoldUtxoResponse](#utxorpc-v1-build-HoldUtxoResponse) stream | Hold UTxOs and receive updates about lost UTxOs |
+| ReadParams | [ReadParamsRequest](#utxorpc-v1alpha-query-ReadParamsRequest) | [ReadParamsResponse](#utxorpc-v1alpha-query-ReadParamsResponse) | Get overall chain state. |
+| ReadUtxos | [ReadUtxosRequest](#utxorpc-v1alpha-query-ReadUtxosRequest) | [ReadUtxosResponse](#utxorpc-v1alpha-query-ReadUtxosResponse) | Read specific UTxOs by reference. |
+| SearchUtxos | [SearchUtxosRequest](#utxorpc-v1alpha-query-SearchUtxosRequest) | [SearchUtxosResponse](#utxorpc-v1alpha-query-SearchUtxosResponse) | Search for UTxO based on a pattern. |
+| StreamUtxos | [ReadUtxosRequest](#utxorpc-v1alpha-query-ReadUtxosRequest) | [ReadUtxosResponse](#utxorpc-v1alpha-query-ReadUtxosResponse) stream | Stream all available utxos |
 
  
 
@@ -1218,7 +1199,7 @@ Request to check the status of submitted transactions.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| txs | [TxInMempool](#utxorpc-v1alpha-submit-TxInMempool) | repeated | List of transaction currently on the mempool. |
+| tx | [TxInMempool](#utxorpc-v1alpha-submit-TxInMempool) | repeated | List of transaction currently on the mempool. |
 
 
 
@@ -1289,7 +1270,7 @@ Response containing references to the submitted transactions.
 <a name="utxorpc-v1alpha-submit-TxPredicate"></a>
 
 ### TxPredicate
-Represents a simple tx predicate that can composed to create more complext ones
+Represents a simple tx predicate that can composed to create more complex ones
 
 
 | Field | Type | Label | Description |
@@ -1599,7 +1580,7 @@ Represents a tx pattern from any supported blockchain.
 <a name="utxorpc-v1alpha-watch-TxPredicate"></a>
 
 ### TxPredicate
-Represents a simple tx predicate that can composed to create more complext ones
+Represents a simple tx predicate that can composed to create more complex ones
 
 
 | Field | Type | Label | Description |

--- a/gen/haskell/stack.yaml
+++ b/gen/haskell/stack.yaml
@@ -6,7 +6,3 @@ extra-deps:
   - proto-lens-protoc-0.8.0.0
   - proto-lens-setup-0.4.0.7
   - ghc-source-gen-0.4.4.1
-
-nix:
-  enable: true
-  packages: [protobuf]

--- a/gen/haskell/stack.yaml
+++ b/gen/haskell/stack.yaml
@@ -6,3 +6,7 @@ extra-deps:
   - proto-lens-protoc-0.8.0.0
   - proto-lens-setup-0.4.0.7
   - ghc-source-gen-0.4.4.1
+
+nix:
+  enable: true
+  packages: [protobuf]

--- a/gen/haskell/utxorpc.cabal
+++ b/gen/haskell/utxorpc.cabal
@@ -3,7 +3,7 @@ cabal-version: 3.0
 name:           utxorpc
 version:        0.0.5.1
 synopsis:       A gRPC interface for UTxO Blockchains
-description:    [UTxO]((https://utxorpc.org/) RPC (u5c for short) is an interface tailored for interactions with UTxO-based blockchains, prioritizing performance and developer experience. By providing a common contract, a range of SDKs, and thorough documentation, UTxO RPC aims to facilitate:
+description:    [UTxO](https://utxorpc.org/) RPC (u5c for short) is an interface tailored for interactions with UTxO-based blockchains, prioritizing performance and developer experience. By providing a common contract, a range of SDKs, and thorough documentation, UTxO RPC aims to facilitate:
 
                 * Reusability: Enabling shared components that can be reused across different projects to simplify the integration effort.
                 * Interoperability: A common interface to simplify integrations between different parties and avoid the common pitfall of vendor lock-in.

--- a/gen/haskell/utxorpc.cabal
+++ b/gen/haskell/utxorpc.cabal
@@ -2,14 +2,17 @@ cabal-version: 3.0
 
 name:           utxorpc
 version:        0.0.5.1
-synopsis:       A gRPC interface for UTxO Blockchains
-description:    [UTxO](https://utxorpc.org/) RPC (u5c for short) is an interface tailored for interactions with UTxO-based blockchains, prioritizing performance and developer experience. By providing a common contract, a range of SDKs, and thorough documentation, UTxO RPC aims to facilitate:
+x-revision: 3
+synopsis:       Generated code for a gRPC interface for UTxO Blockchains
+description:    [UTxO RPC](https://utxorpc.org/) (u5c for short) is an interface tailored for interactions with UTxO-based blockchains, prioritizing performance and developer experience. By providing a common contract, a range of SDKs, and thorough documentation, UTxO RPC aims to facilitate:
 
                 * Reusability: Enabling shared components that can be reused across different projects to simplify the integration effort.
                 * Interoperability: A common interface to simplify integrations between different parties and avoid the common pitfall of vendor lock-in.
                 * Performance: A serialized binary format which is compact and efficient, resulting in smaller message sizes and reduced network overhead compared to its JSON counterpart
 
-                Please note that UTxO RPC is just a specification of an interface between agents and the blockchain, it doesn't provide any concrete client / provider implementations. The primary purpose of u5c is to define a set of standardized methods, data structures, and communication patterns.
+                Please note that this package only contains the generated Haskell code from the u5c specification. To write a u5c implementation, please see the [client](https://hackage.haskell.org/package/utxorpc-client) or [server](https://hackage.haskell.org/package/utxorpc-server) SDK.
+
+                For documentation on the specification, see [https://utxorpc.org](https://utxorpc.org/).
 
 category:       Network, GRPC, Blockchain, Cardano
 homepage:       https://github.com/utxorpc/spec#readme


### PR DESCRIPTION
# In this PR
1. Minor modifications to Haskell package metadata.
2. Include Haddock (documentation) generation and publishing in the CI workflow.
3. Include changes to documentation markdown after running `buf generate proto`.
    1. I'm not sure what the current process is regarding documentation, so I don't know if including these changes is appropriate. @wolf31o2 do you know?