### PR TITLE
feat: fill gaps to work as Blaze / Lucid provider

### DIFF
--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -374,7 +374,7 @@ message CostModels {
 }
 
 message Params {
-  uint64 coins_per_utxo_byte = 1; //
+  uint64 coins_per_utxo_byte = 1; // The number of coins per UTXO byte.
   uint64 max_tx_size = 2; // The maximum transaction size.
   uint64 min_fee_coefficient = 3; // The minimum fee coefficient.
   uint64 min_fee_constant = 4; // The minimum fee constant.

--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -349,4 +349,69 @@ message TxPattern {
 // PARAMS
 // ======
 
-message Params {}
+message ExUnits {
+  uint64 steps = 1;
+  uint64 memory = 2;
+}
+
+message ExPrices {
+  RationalNumber steps = 1;
+  RationalNumber memory = 2;
+}
+
+message ProtocolVersion {
+  uint32 major = 1;
+  uint32 minor = 2;
+}
+
+message CostModel {
+  // TODO
+}
+
+message CostModels {
+  CostModel plutus_v1 = 1;
+  CostModel plutus_v2 = 2;
+}
+
+message Params {
+  uint64 coins_per_utxo_byte = 1; //
+  uint64 max_tx_size = 2; // The maximum transaction size.
+  uint64 min_fee_coefficient = 3; // The minimum fee coefficient.
+  uint64 min_fee_constant = 4; // The minimum fee constant.
+  uint64 max_block_body_size = 5; // The maximum block body size.
+  uint64 max_block_header_size = 6; // The maximum block header size.
+  uint64 stake_key_deposit = 7; // The stake key deposit.
+  uint64 pool_deposit = 8; // The pool deposit.
+  uint64 pool_retirement_epoch_bound = 9; // The pool retirement epoch bound.
+  uint64 desired_number_of_pools = 10; // The desired number of pools.
+  RationalNumber pool_influence = 11; // The pool influence.
+  RationalNumber monetary_expansion = 12; // The monetary expansion.
+  RationalNumber treasury_expansion = 13; // The treasury expansion.
+  uint64 min_pool_cost = 14; // The minimum pool cost.
+  ProtocolVersion protocol_version = 15; // The protocol version.
+  uint64 max_value_size = 16; // The maximum value size.
+  uint64 collateral_percentage = 17; // The collateral percentage.
+  uint64 max_collateral_inputs = 18; // The maximum collateral inputs.
+  CostModels cost_models = 19; // The cost models.
+  ExPrices prices = 20; // The prices.
+  ExUnits max_execution_units_per_transaction = 21; // The maximum execution units per transaction.
+  ExUnits max_execution_units_per_block = 22; // The maximum execution units per block.
+}
+
+// EVALUATION
+// ==========
+
+message EvalError {
+  string msg = 1;
+}
+
+message EvalTrace {
+  string msg = 1;
+}
+
+message TxEval {
+  uint64 fee = 1;
+  ExUnits ex_units = 2;
+  repeated EvalError errors = 3;
+  repeated EvalTrace traces = 4;
+}

--- a/proto/utxorpc/v1alpha/query/query.proto
+++ b/proto/utxorpc/v1alpha/query/query.proto
@@ -64,6 +64,7 @@ message AnyUtxoData {
 // Request to get specific UTxOs
 message ReadUtxosRequest {
   repeated TxoRef keys = 1; // List of keys UTxOs.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
 }
 
 // Response containing the UTxOs associated with the requested addresses.
@@ -75,6 +76,7 @@ message ReadUtxosResponse {
 // Reques to search for UTxO based on a pattern.
 message SearchUtxosRequest {
   UtxoPredicate predicate = 1; // Pattern to match UTxOs by.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
 }
 
 // Response containing the UTxOs that match the requested addresses.
@@ -83,14 +85,36 @@ message SearchUtxosResponse {
   ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
 }
 
+// Request to get data (as in plural of datum)
+message ReadDataRequest {
+  repeated bytes keys = 1;
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields in the response.
+}
+
+// An evenlope that holds a datum for any of the compatible chains
+message AnyChainDatum {
+  bytes key = 1;
+  bytes native_bytes = 2; // An opaque bytestring corresponding to native representation in the source chain.
+  oneof parsed_state {
+    utxorpc.v1alpha.cardano.PlutusData cardano = 3; // A cardano UTxO
+  }
+}
+
+// Response containing data (as in plural of datum)
+message ReadDataResponse {
+  repeated AnyChainDatum values = 1; // The value of each datum.
+  ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
+}
+
 // Service definition for querying the state of the chain.
 service QueryService {
   rpc ReadParams(ReadParamsRequest) returns (ReadParamsResponse); // Get overall chain state.
   rpc ReadUtxos(ReadUtxosRequest) returns (ReadUtxosResponse); // Read specific UTxOs by reference.
   rpc SearchUtxos(SearchUtxosRequest) returns (SearchUtxosResponse); // Search for UTxO based on a pattern.
-  rpc StreamUtxos(ReadUtxosRequest) returns (stream ReadUtxosResponse); // Stream all available utxos
+  rpc ReadData(ReadDataRequest) returns (ReadDataResponse); // Read specific datum by hash
 
   // TODO: decide if we want to expand the scope
+  // rpc DumpUtxos(ReadUtxosRequest) returns (stream ReadUtxosResponse); // Dump all available utxos
   // rpc ReadAccount(ReadAccountRequest) returns (ReadAccountReponse); // Get state of a particular account
   // rpc ReadTxs(GetTxRequest) returns (GetTxResponse); // Get Txs by by chain-specific criteria.
 }

--- a/proto/utxorpc/v1alpha/submit/submit.proto
+++ b/proto/utxorpc/v1alpha/submit/submit.proto
@@ -12,6 +12,23 @@ message AnyChainTx {
   }
 }
 
+// Request to evaluate transactions without submitting.
+message EvalTxRequest {
+  repeated AnyChainTx tx = 1; // List of transactions to evaluate.
+}
+
+// Report containing the result of evaluating a particular transaction
+message AnyChainEval {
+  oneof chain {
+    utxorpc.v1alpha.cardano.TxEval cardano = 1; // A Cardano tx evaluation report.
+  }
+}
+
+// Response containing the reports form the transaction evaluation.
+message EvalTxResponse {
+  repeated AnyChainEval report = 1;
+}
+
 // Request to submit transactions to the blockchain.
 message SubmitTxRequest {
   repeated AnyChainTx tx = 1; // List of transactions to submit.
@@ -85,6 +102,7 @@ message WatchMempoolResponse {
 
 // Service definition for submitting transactions and checking their status.
 service SubmitService {
+  rpc EvalTx(EvalTxRequest) returns (EvalTxResponse); // Evaluates a transaction without submitting it.
   rpc SubmitTx(SubmitTxRequest) returns (SubmitTxResponse); // Submit transactions to the blockchain.
   rpc WaitForTx(WaitForTxRequest) returns (stream WaitForTxResponse); // Wait for transactions to reach a certain stage and stream the updates.
   rpc ReadMempool(ReadMempoolRequest) returns (ReadMempoolResponse); // Returns a point-in-time snapshot of the mempool.


### PR DESCRIPTION
This PR fills the gaps to allow U5C to work as a provider for tx-builder libraries such as Blaze and Lucid.

In particular, it adds:
- method to query datums by hash
- missing definition of cardano ledger pparams
- method to evaluate tx fees in submit module

The other required endpoints where already available.