### PR TITLE
Modify AnyChainBlock to allow fetching native bytes

### DIFF
--- a/proto/utxorpc/v1alpha/sync/sync.proto
+++ b/proto/utxorpc/v1alpha/sync/sync.proto
@@ -12,8 +12,8 @@ message BlockRef {
 }
 
 message AnyChainBlock {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
   oneof chain {
-    bytes raw = 1; // Original bytes for a raw block
     utxorpc.v1alpha.cardano.Block cardano = 2; // A parsed Cardano block.
   }
 }


### PR DESCRIPTION
Previously, you could fetch *either* the raw bytes, *or* the chain, but not both; But they aren't mutually exclusive: it makes total sense to return *both* the native bytes and the interpreted structure according to some chain. This replaces `raw` with `native_bytes`

Comes out of a conversation with @scarmuega and @wolf31o2 on discord.