### PR TITLE
feat(cardano): Add `native_bytes` field into `PlutusData`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ gen/rust/src
 !gen/rust/src/lib.rs
 gen/python/utxorpc_spec
 gen/python/dist
+spec.sln

--- a/gen/node/.gitignore
+++ b/gen/node/.gitignore
@@ -5,3 +5,4 @@
 /node_modules
 
 package-lock.json
+bun.lockb

--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -170,14 +170,14 @@ message PlutusDataPair {
 
 // Represents a Plutus data item in Cardano.
 message PlutusData {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
   oneof plutus_data {
-    Constr constr = 1; // Constructor.
-    PlutusDataMap map = 2; // Map of Plutus data.
-    BigInt big_int = 3; // Big integer.
-    bytes bounded_bytes = 4; // Bounded bytes.
-    PlutusDataArray array = 5; // Array of Plutus data.
+    Constr constr = 2; // Constructor.
+    PlutusDataMap map = 3; // Map of Plutus data.
+    BigInt big_int = 4; // Big integer.
+    bytes bounded_bytes = 5; // Bounded bytes.
+    PlutusDataArray array = 6; // Array of Plutus data.
   }
-  bytes native_bytes = 6; // Native bytes field
 }
 
 // Represents a map of Plutus data in Cardano.

--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -177,6 +177,7 @@ message PlutusData {
     bytes bounded_bytes = 4; // Bounded bytes.
     PlutusDataArray array = 5; // Array of Plutus data.
   }
+  bytes native_bytes = 6; // Native bytes field
 }
 
 // Represents a map of Plutus data in Cardano.

--- a/proto/utxorpc/v1alpha/query/query.proto
+++ b/proto/utxorpc/v1alpha/query/query.proto
@@ -54,8 +54,8 @@ message UtxoPredicate {
 
 // An evenlope that holds an UTxO from any of compatible chains
 message AnyUtxoData {
-  TxoRef txo_ref = 1; // Hash of the previous transaction.
-  bytes native_bytes = 2; // An opaque bytestring corresponding to native representation in the source chain.
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  TxoRef txo_ref = 2; // Hash of the previous transaction.
   oneof parsed_state {
     utxorpc.v1alpha.cardano.TxOutput cardano = 3; // A cardano UTxO
   }
@@ -93,8 +93,8 @@ message ReadDataRequest {
 
 // An evenlope that holds a datum for any of the compatible chains
 message AnyChainDatum {
-  bytes key = 1;
-  bytes native_bytes = 2; // An opaque bytestring corresponding to native representation in the source chain.
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  bytes key = 2;
   oneof parsed_state {
     utxorpc.v1alpha.cardano.PlutusData cardano = 3; // A cardano UTxO
   }


### PR DESCRIPTION
This PR adds `native_bytes` field into `PlutusData` cardano message

this is useful for stuff like **Transaction Builder** integrations where there is already a built CBOR (de)serializer.