### PR TITLE
refactor: avoid recursive `native_bytes` for`PlutusData`

### DIFF
--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -31,13 +31,13 @@ message TxOutput {
   uint64 coin = 2; // Amount of ADA in the output.
   repeated Multiasset assets = 3; // Additional native (non-ADA) assets in the output.
   Datum datum = 4; // Plutus data associated with the output.
-  bytes datum_hash = 5; // Hash of the Plutus data.
-  Script script = 6; // Script associated with the output.
+  Script script = 5; // Script associated with the output.
 }
 
 message Datum {
   bytes native_bytes = 1; // Original bytes as defined by the chain
   PlutusData parsed_state = 2; // Parsed PlutusData
+  bytes datum_hash = 3; // Hash of the Plutus data.
 }
 
 // Represents a custom asset in the Cardano blockchain.

--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -30,9 +30,14 @@ message TxOutput {
   bytes address = 1; // Address receiving the output.
   uint64 coin = 2; // Amount of ADA in the output.
   repeated Multiasset assets = 3; // Additional native (non-ADA) assets in the output.
-  PlutusData datum = 4; // Plutus data associated with the output.
+  Datum datum = 4; // Plutus data associated with the output.
   bytes datum_hash = 5; // Hash of the Plutus data.
   Script script = 6; // Script associated with the output.
+}
+
+message Datum {
+  bytes native_bytes = 1; // Original bytes as defined by the chain
+  PlutusData parsed_state = 2; // Datum data.
 }
 
 // Represents a custom asset in the Cardano blockchain.
@@ -170,7 +175,6 @@ message PlutusDataPair {
 
 // Represents a Plutus data item in Cardano.
 message PlutusData {
-  bytes native_bytes = 1; // Original bytes as defined by the chain
   oneof plutus_data {
     Constr constr = 2; // Constructor.
     PlutusDataMap map = 3; // Map of Plutus data.

--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -37,7 +37,7 @@ message TxOutput {
 
 message Datum {
   bytes native_bytes = 1; // Original bytes as defined by the chain
-  PlutusData parsed_state = 2; // Datum data.
+  PlutusData parsed_state = 2; // Parsed PlutusData
 }
 
 // Represents a custom asset in the Cardano blockchain.

--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -14,7 +14,7 @@ enum RedeemerPurpose {
 // Redeemer information for a Plutus script.
 message Redeemer {
   RedeemerPurpose purpose = 1; // Purpose of the redeemer.
-  PlutusData datum = 2; // Plutus data associated with the redeemer.
+  PlutusData payload = 2; // Plutus data associated with the redeemer.
 }
 
 // Represents a transaction input in the Cardano blockchain.
@@ -35,9 +35,9 @@ message TxOutput {
 }
 
 message Datum {
-  bytes native_bytes = 1; // Original bytes as defined by the chain
-  PlutusData parsed_state = 2; // Parsed PlutusData
-  bytes datum_hash = 3; // Hash of the Plutus data.
+  bytes hash = 1; // Hash of this datum as seen on-chain
+  PlutusData payload = 2; // Parsed Plutus data payload
+  bytes original_cbor = 3; // Original cbor-encoded data as seen on-chain
 }
 
 // Represents a custom asset in the Cardano blockchain.


### PR DESCRIPTION
This PR introduces `Datum` struct as the container for `PlutusData` in a `TxOutput`, this avoids having recursive `native_bytes` within `PlutusData` itself.