### PR TITLE
chore: update proto-lens-runtime dependency to >= version 0.7.0.6

### DIFF
--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -77,22 +77,22 @@ jobs:
           repository-token: ${{ secrets.GOSDK_REPOSITORY_TOKEN }}
           mode: ${{ inputs.mode }}
 
-  # publish-haskell:
-  #   runs-on: ubuntu-latest
+  publish-haskell:
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-  #     - uses: actions/download-artifact@v4
-  #       with:
-  #         name: codegen
-  #         path: ./codegen
+      - uses: actions/download-artifact@v4
+        with:
+          name: codegen
+          path: ./codegen
 
-  #     - uses: ./.github/actions/publish-haskell
-  #       with:
-  #         registry-token: ${{ secrets.HACKAGE_REGISTRY_TOKEN }}
-  #         mode: ${{ inputs.mode }}
+      - uses: ./.github/actions/publish-haskell
+        with:
+          registry-token: ${{ secrets.HACKAGE_REGISTRY_TOKEN }}
+          mode: ${{ inputs.mode }}
 
   publish-dotnet:
     runs-on: ubuntu-latest

--- a/gen/haskell/utxorpc.cabal
+++ b/gen/haskell/utxorpc.cabal
@@ -43,5 +43,5 @@ library
     , proto-lens >= 0.7.1 && < 0.8
     -- >= 0.7.2 required as it contains support for `FieldMask`
     , proto-lens-protobuf-types >= 0.7.2 && < 0.8
-    , proto-lens-runtime >= 0.8.0 && < 0.8
+    , proto-lens-runtime >= 0.7.0.6
   default-language: Haskell2010


### PR DESCRIPTION
This PR solves CI haskell dependency issue and re-enables haskell workflow