### PR TITLE
ci(node): authentication publish workflow fix

### DIFF
--- a/.github/actions/publish-node/action.yml
+++ b/.github/actions/publish-node/action.yml
@@ -18,6 +18,7 @@ runs:
         node-version: 20.11.0
         cache: "npm"
         cache-dependency-path: "codegen/node/package.json"
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Typescript Transpile
       shell: bash


### PR DESCRIPTION
## PR Summary: Adding registry-url to npm publish workflow

This PR adds the `registry-url` parameter to the `actions/setup-node` step in our npm publish workflow.

### Key Change:
```yaml
- name: Setup npm
      uses: actions/setup-node@v4
      with:
        node-version: 20.11.0
        cache: "npm"
        cache-dependency-path: "codegen/node/package.json"
        registry-url: 'https://registry.npmjs.org'
```

### Why registry-url is needed:

1. **Authentication Setup**: It configures npm to use the `NODE_AUTH_TOKEN` for the specified registry.
2. **Security**: Ensures the auth token is only used for the intended registry.
3. **GitHub Actions Requirement**: Unlike local environments, GitHub Actions needs this explicit configuration to properly authenticate npm operations.

Without `registry-url`, the workflow fails to authenticate, even with `NODE_AUTH_TOKEN` set, due to GitHub Actions' specific behavior.