### PR TITLE
feat(submit): TxEval now returns Redeemers instead of ExUnits, Redeemer Include (Index and ExUnits)

### DIFF
--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -16,7 +16,9 @@ enum RedeemerPurpose {
 // Redeemer information for a Plutus script.
 message Redeemer {
   RedeemerPurpose purpose = 1; // Purpose of the redeemer.
-  PlutusData payload = 2; // Plutus data associated with the redeemer.
+  uint32 index = 2; // Index of the redeemer.
+  PlutusData payload = 3; // Plutus data associated with the redeemer.
+  ExUnits ex_units = 4; // Execution units consumed by the redeemer.
 }
 
 // Represents a transaction input in the Cardano blockchain.
@@ -515,7 +517,7 @@ message EvalTrace {
 
 message TxEval {
   uint64 fee = 1;
-  ExUnits ex_units = 2;
+  repeated Redeemer redeemers = 2;
   repeated EvalError errors = 3;
   repeated EvalTrace traces = 4;
 }

--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -16,8 +16,8 @@ enum RedeemerPurpose {
 // Redeemer information for a Plutus script.
 message Redeemer {
   RedeemerPurpose purpose = 1; // Purpose of the redeemer.
-  uint32 index = 2; // Index of the redeemer.
-  PlutusData payload = 3; // Plutus data associated with the redeemer.
+  PlutusData payload = 2; // Plutus data associated with the redeemer.
+  uint32 index = 3; // Index of the redee mer.
   ExUnits ex_units = 4; // Execution units consumed by the redeemer.
 }
 

--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -517,7 +517,8 @@ message EvalTrace {
 
 message TxEval {
   uint64 fee = 1;
-  repeated Redeemer redeemers = 2;
+  ExUnits ex_units = 2;
   repeated EvalError errors = 3;
   repeated EvalTrace traces = 4;
+  repeated Redeemer redeemers = 5;
 }


### PR DESCRIPTION
This PR updates the submit module's TxEval result to return `Repeated Redeemer` instead of only `ExUnits`. This change enables transaction builders to gain a more fine-grained perspective of the evaluation process.

Additionally, it modifies the `Redeemer` structure to align more closely with the CDDL specification by adding the missing `Index` and `ExUnits` fields.