### PR TITLE
feat: add original_cbor field to Redeemer message

### DIFF
--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -19,6 +19,7 @@ message Redeemer {
   PlutusData payload = 2; // Plutus data associated with the redeemer.
   uint32 index = 3; // Index of the redee mer.
   ExUnits ex_units = 4; // Execution units consumed by the redeemer.
+  bytes original_cbor = 5; // Original cbor-encoded data as seen on-chain
 }
 
 // Represents a transaction input in the Cardano blockchain.


### PR DESCRIPTION
This PR adds the `original_cbor` to the `Redeemer` message to allow tools to use (de)serializers and consume the redeemer directly.

This closes: #132 