### PR TITLE
Add json (typebox) types

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -21,6 +21,9 @@ filename = "gen/rust/Cargo.toml"
 filename = "gen/node/package.json"
 
 [[tool.bumpversion.files]]
+filename = "gen/jsonschema/package.json"
+
+[[tool.bumpversion.files]]
 filename = "gen/haskell/utxorpc.cabal"
 
 [[tool.bumpversion.files]]

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ gen/go/utxorpc/
 gen/haskell/Proto
 gen/node/src/
 gen/openapi/
+gen/jsonschema/schema/
+gen/jsonschema/src/
 gen/rust/src
 !gen/rust/src/lib.rs
 gen/python/utxorpc_spec

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,5 @@
 all:
 	buf generate proto
 	find gen/python/utxorpc_spec -type f -exec sed -i '' 's@from utxorpc@from utxorpc_spec.utxorpc@g' {} \;
+	mkdir -p gen/jsonschema/src
+	cd gen/jsonschema/schema && npx @paima/schema2typebox --protobuf -i **/*.jsonschema.json -o ../src/index.ts

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -68,6 +68,9 @@ plugins:
     opt:
       - target=ts
 
+  - plugin: buf.build/bufbuild/protoschema-jsonschema
+    out: gen/jsonschema/schema
+
   # haskell
 
   - plugin: haskell-protolens

--- a/gen/jsonschema/package.json
+++ b/gen/jsonschema/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@utxorpc/jsonschema",
+  "version": "0.16.0",
+  "description": "UTxO RPC auto-generated JSON Schema",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
+  "module": "./lib/index.mjs",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      },
+      "import": {
+        "types": "./lib/index.d.ts",
+        "import": "./lib/index.mjs"
+      }
+    },
+    "./schema/*": "./schema/*"
+  },
+  "type": "module",
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir lib"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/utxorpc/spec.git"
+  },
+  "keywords": [
+    "utxorpc",
+    "grpc",
+    "blockchain"
+  ],
+  "author": "utxorpc.org",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/utxorpc/spec/issues"
+  },
+  "homepage": "https://github.com/utxorpc/spec#readme",
+  "devDependencies": {
+    "tsup": "^8.4.0",
+    "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.33"
+  }
+}

--- a/gen/jsonschema/tsconfig.json
+++ b/gen/jsonschema/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "./lib",
+    "declaration": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+} 


### PR DESCRIPTION
Generated JS code for protobuf contains `toJson` functions, but return type is just a generic json object making it a bit hard to work with

To solve this, I did two steps:
1. I added a new codegen option for jsonschema, so that we can get a schema for utxorpc
2. I used this schema and the [schema2typebox](https://github.com/xddq/schema2typebox) tool to generate [typebox](https://github.com/sinclairzx81/typebox) constructs for all the entries. These can be used not only to validate data, but it also allows you to have types on the result of `toJson`

## Example 1) Checking object shapes

```ts
import type { Static } from '@sinclair/typebox'
import { WatchMempoolRequest } from '@utxorpc/jsonschema';

// this checks the object is the right type to be turned into protobuf later
const matchRequest: Static<typeof WatchMempoolRequest> = {
  fieldMask: undefined,
  predicate: {
    match: {
      cardano: {
        consumes: {
          address: {
            exactAddress: "addr_test1q..."
          }
        }
      }
    }
  },
}
```

## Example 2) Importing the json schema

The project is setup so that you can also import the raw json schema if needed from typescript

```ts
import * as addressPatternSchema from '@utxorpc/jsonschema/schema/utxorpc.v1alpha.cardano.AddressPattern.schema.json' with { type: 'json' };
console.log(addressPatternSchema);
```

## Why not make these part of the node package

This is a valid question, and I think there are two main reasons why:
1. **Separate concerns**: It's possible people want to use the jsonschema files *without* using Javascript (ex: to use with their own tool that consumes jsonschema). It maybe too much to combine all jsonschema files AND all generates JS files into the same package given they're separate concerns
2. **Avoid mangling**: bundling this into the node package would require a script that goes in and modifies the files generates by the JS codegen tool. Although probably the format of the code is stable and so it's not a problem, having scripts that go in to modify the JS files and package.json generated by another codegen tool feels a bit flakey.