### PR TITLE
chore(python): update poetry-core and dependencies for compatibility

### DIFF
--- a/gen/python/pyproject.toml
+++ b/gen/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system] # https://python-poetry.org/docs/pyproject/#poetry-and-pep-517
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=2.1.3"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry] # https://python-poetry.org/docs/pyproject/
@@ -14,10 +14,10 @@ repository = "https://github.com/utxorpc/spec"
 include = ["utxorpc_spec/**/*.py", "utxorpc_spec/**/*.pyi"]
 
 [tool.poetry.dependencies] # https://python-poetry.org/docs/dependency-specification/
-python = ">=3.8,<4.0"
-grpcio = "^1.64.1"
-protobuf = "^5.27.1"
-grpc-stubs = "^1.53.0.5"
+python = ">=3.9,<4.0"
+grpcio = "^1.73.1"
+protobuf = "^6.31.1"
+grpc-stubs = "^1.53.0.6"
 
 [[tool.poetry.source]]
 name = "pypi"


### PR DESCRIPTION
 Changes
 
  - ⬆️ poetry-core: >=1.0.0 → >=2.1.3 (latest stable build system)
  - ⬆️ grpcio: ^1.64.1 → ^1.73.1 (latest stable version)
  - ⬆️ protobuf: ^5.27.1 → ^6.31.1 (required by generated code)
  - ⬆️ grpc-stubs: ^1.53.0.5 → ^1.53.0.6 (latest patch)
  - ⬆️ Python requirement: >=3.8,<4.0 → >=3.9,<4.0 (required by latest
  dependencies)
  
  Technical Details

  - The protobuf upgrade is mandatory to match the generated code's runtime
   validation
  - grpcio 1.73.1 is fully compatible with protobuf 6.31.1
  - Python 3.9+ is required by the latest grpcio and protobuf versions