### PR TITLE
feat(submit): add error messages to transaction submission result

### DIFF
--- a/proto/utxorpc/v1alpha/submit/submit.proto
+++ b/proto/utxorpc/v1alpha/submit/submit.proto
@@ -12,9 +12,9 @@ message AnyChainTx {
   }
 }
 
-// Request to evaluate transactions without submitting.
+// Request to evaluate transaction without submitting.
 message EvalTxRequest {
-  repeated AnyChainTx tx = 1; // List of transactions to evaluate.
+  AnyChainTx tx = 1; // A transaction to evaluate.
 }
 
 // Report containing the result of evaluating a particular transaction
@@ -26,25 +26,17 @@ message AnyChainEval {
 
 // Response containing the reports form the transaction evaluation.
 message EvalTxResponse {
-  repeated AnyChainEval report = 1;
+  AnyChainEval report = 1;
 }
 
-// Request to submit transactions to the blockchain.
+// Request to submit a transaction to the blockchain.
 message SubmitTxRequest {
-  repeated AnyChainTx tx = 1; // List of transactions to submit.
+  AnyChainTx tx = 1; // A transaction to submit.
 }
 
-// The result of a submission of a single transaction.
-message TxSubmitResult {
-  oneof result {
-    bytes ref = 1; // Transaction reference.
-    string error_message = 2; // The error message, when the transaction submission was not successful.
-  }
-}
-
-// Response containing references to the submitted transactions or error messages.
+// Response containing references to the submitted transactions.
 message SubmitTxResponse {
-  repeated TxSubmitResult results = 1; // List of either transaction references or error messages.
+  bytes ref = 1; // A transaction reference returned upon successful submission.
 }
 
 // Enum representing the various stages of a transaction's lifecycle.

--- a/proto/utxorpc/v1alpha/submit/submit.proto
+++ b/proto/utxorpc/v1alpha/submit/submit.proto
@@ -34,9 +34,17 @@ message SubmitTxRequest {
   repeated AnyChainTx tx = 1; // List of transactions to submit.
 }
 
-// Response containing references to the submitted transactions.
+// The result of a submission of a single transaction.
+message TxSubmitResult {
+  oneof result {
+    bytes ref = 1; // Transaction reference.
+    string error_message = 2; // The error message, when the transaction submission was not successful.
+  }
+}
+
+// Response containing references to the submitted transactions or error messages.
 message SubmitTxResponse {
-  repeated bytes ref = 1; // List of transaction references.
+  repeated TxSubmitResult results = 1; // List of either transaction references or error messages.
 }
 
 // Enum representing the various stages of a transaction's lifecycle.


### PR DESCRIPTION
It would be useful to have an error message in the response if the transaction submission has failed. This PR adds a `oneof` field with an error message instead of a transaction reference if there was an error.