### PR TITLE
feat: add watcher correlation and certificate filtering

### DIFF
--- a/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -516,6 +516,38 @@ message AssetPattern {
   bytes asset_name = 2; // The asset should present this name
 }
 
+// Pattern of a certificate that can be used to evaluate matching predicates.
+message CertificatePattern {
+  oneof certificate_type {
+    StakeCredential stake_registration = 1; // Match stake registration for this credential
+    StakeCredential stake_deregistration = 2; // Match stake deregistration for this credential
+    StakeDelegationPattern stake_delegation = 3; // Match stake delegation pattern
+    PoolRegistrationPattern pool_registration = 4; // Match pool registration pattern
+    PoolRetirementPattern pool_retirement = 5; // Match pool retirement pattern
+    bytes any_stake_credential = 6; // Match any certificate involving this stake credential
+    bytes any_pool_keyhash = 7; // Match any certificate involving this pool
+    bytes any_drep = 8; // Match any certificate involving this DRep
+  }
+}
+
+// Pattern for stake delegation certificates
+message StakeDelegationPattern {
+  StakeCredential stake_credential = 1; // Match delegations from this credential
+  bytes pool_keyhash = 2; // Match delegations to this pool
+}
+
+// Pattern for pool registration certificates
+message PoolRegistrationPattern {
+  bytes operator = 1; // Match registrations by this operator
+  bytes pool_keyhash = 2; // Match registrations for this pool (derived from operator)
+}
+
+// Pattern for pool retirement certificates
+message PoolRetirementPattern {
+  bytes pool_keyhash = 1; // Match retirements of this pool
+  uint64 epoch = 2; // Match retirements in this epoch
+}
+
 // Pattern of a tx output that can be used to evaluate matching predicates.
 message TxOutputPattern {
   AddressPattern address = 1; // Match any address in the output that exhibits this pattern.
@@ -529,6 +561,7 @@ message TxPattern {
   AddressPattern has_address = 3; // Match any address (inputs, outputs, collateral, etc) that exhibits this pattern.
   AssetPattern moves_asset = 4; // Match any asset that exhibits this pattern.
   AssetPattern mints_asset = 5; // Match any tx that either mint or burn the the asset pattern.
+  CertificatePattern has_certificate = 6; // Match any transaction that includes this certificate pattern.
 }
 
 // PARAMS

--- a/proto/utxorpc/v1alpha/watch/watch.proto
+++ b/proto/utxorpc/v1alpha/watch/watch.proto
@@ -49,11 +49,12 @@ message AnyChainTx {
   AnyChainBlock block = 2; // Block containing the transaction
 }
 
-// Response containing the matching chain transactions.
+// Response containing the matching chain transactions or block progress signals.
 message WatchTxResponse {
   oneof action {
     AnyChainTx apply = 1; // Apply this transaction.
     AnyChainTx undo = 2; // Undo this transaction.
+    BlockRef idle = 3; // No-match signal for a block.
   }
 }
 


### PR DESCRIPTION
## Summary
- Resolves watcher correlation issue (#135) by adding `idle` signals for block progress tracking
- Adds comprehensive certificate filtering (#145) to enable transaction filtering by certificate types

## Changes

### Watcher Correlation (#135)
- Add `idle` field to `WatchTxResponse` for explicit no-match block signals
- Enable clients to correlate state across multiple watchers with certainty
- Maintain proper block ordering semantics for rollbacks

### Certificate Filtering (#145)
- Add `CertificatePattern` message with comprehensive certificate type matching
- Support specific patterns for stake delegation, pool registration, and pool retirement
- Enable filtering by stake credentials, pool keyhashes, and DReps
- Add `has_certificate` field to `TxPattern` for transaction-level certificate filtering

## Use Cases
- **Delegation tracking**: Filter transactions containing delegations to specific pools
- **Pool lifecycle monitoring**: Track pool registrations and retirements
- **Multi-watcher synchronization**: Correlate progress across different transaction watchers

## Test Plan
- [ ] Verify `idle` signals maintain proper block ordering
- [ ] Test certificate pattern matching for delegation scenarios
- [ ] Validate multi-watcher correlation with `idle` semantics
- [ ] Confirm backwards compatibility for existing clients