### PR TITLE
Mark optional fields in SearchUtxosRequest with `optional`

### DIFF
--- a/proto/utxorpc/v1beta/cardano/cardano.proto
+++ b/proto/utxorpc/v1beta/cardano/cardano.proto
@@ -544,15 +544,15 @@ message UpdateDRepCert {
 
 // Pattern of an address that can be used to evaluate matching predicates.
 message AddressPattern {
-  bytes exact_address = 1; // The address should match this exact address value.
-  bytes payment_part = 2; // The payment part of the address should match this value.
-  bytes delegation_part = 3; // The delegation part of the address should match this value.
+  optional bytes exact_address = 1; // The address should match this exact address value.
+  optional bytes payment_part = 2; // The payment part of the address should match this value.
+  optional bytes delegation_part = 3; // The delegation part of the address should match this value.
 }
 
 // Pattern of a native asset that can be used to evaluate matching predicates.
 message AssetPattern {
-  bytes policy_id = 1; // The asset should belong to this policy id
-  bytes asset_name = 2; // The asset should present this name
+  optional bytes policy_id = 1; // The asset should belong to this policy id
+  optional bytes asset_name = 2; // The asset should present this name
 }
 
 // Pattern of a certificate that can be used to evaluate matching predicates.
@@ -589,8 +589,8 @@ message PoolRetirementPattern {
 
 // Pattern of a tx output that can be used to evaluate matching predicates.
 message TxOutputPattern {
-  AddressPattern address = 1; // Match any address in the output that exhibits this pattern.
-  AssetPattern asset = 2; // Match any asset in the output that exhibits this pattern.
+  optional AddressPattern address = 1; // Match any address in the output that exhibits this pattern.
+  optional AssetPattern asset = 2; // Match any asset in the output that exhibits this pattern.
 }
 
 // Pattern of a Tx that can be used to evaluate matching predicates.

--- a/proto/utxorpc/v1beta/query/query.proto
+++ b/proto/utxorpc/v1beta/query/query.proto
@@ -81,7 +81,7 @@ message AnyUtxoPattern {
 
 // Represents a simple utxo predicate that can composed to create more complex ones
 message UtxoPredicate {
-  AnyUtxoPattern match = 1; // Predicate is true if tx exhibits pattern.
+  optional AnyUtxoPattern match = 1; // Predicate is true if tx exhibits pattern.
   repeated UtxoPredicate not = 2; // Predicate is true if tx doesn't exhibit pattern.
   repeated UtxoPredicate all_of = 3; // Predicate is true if utxo exhibits all of the patterns.
   repeated UtxoPredicate any_of = 4; // Predicate is true if utxo exhibits any of the patterns.
@@ -111,17 +111,17 @@ message ReadUtxosResponse {
 
 // Request to search for UTxO based on a pattern.
 message SearchUtxosRequest {
-  UtxoPredicate predicate = 1; // Pattern to match UTxOs by.
+  optional UtxoPredicate predicate = 1; // Pattern to match UTxOs by.
   google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
-  int32 max_items = 3; // The maximum number of items to return.
-  string start_token = 4; // The next_page_token value returned from a previous request, if any.
+  optional int32 max_items = 3; // The maximum number of items to return.
+  optional string start_token = 4; // The next_page_token value returned from a previous request, if any.
 }
 
 // Response containing the UTxOs that match the requested addresses.
 message SearchUtxosResponse {
   repeated AnyUtxoData items = 1; // List of UTxOs.
   ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
-  string next_token = 3; // Token to retrieve the next page of results, or empty if there are no more results.
+  optional string next_token = 3; // Token to retrieve the next page of results, absent if there are no more results.
 }
 
 // Request to get data (as in plural of datum)


### PR DESCRIPTION
## Motivation

In proto3, fields without the `optional` keyword are not given presence tracking.
An empty `bytes` field and one that was never set are represented identically on the wire and in generated code.
As a result, "the client left this filter blank" cannot be distinguished from "the client wants to match on empty bytes" by the server, and "no more pages" cannot be distinguished from "an empty token was set" by the client.

The `SearchUtxos` predicate hierarchy is built on combining address patterns, asset patterns and boolean operators.
Each pattern field is intended as a filter: when present it should constrain the result set, and when absent it should be ignored.
Without `optional`, the proto3 default (empty bytes, zero, empty string) must be treated as "absent" by implementations.
This convention is fragile and cannot be enforced by the encoding itself.

With `optional`, fields are represented with presence-aware types in generated code (e.g. `Maybe` in Haskell, `has_` checks in other languages), so the "absent vs default" distinction is handled naturally rather than through ad-hoc empty checks.

## Changes

The following fields are marked as `optional` to enable presence semantics:

- `AddressPattern`: `exact_address`, `payment_part`, `delegation_part`
- `AssetPattern`: `policy_id`, `asset_name`
- `TxOutputPattern`: `address`, `asset`
- `UtxoPredicate`: `match`
- `SearchUtxosRequest`: `predicate`, `max_items`, `start_token`
- `SearchUtxosResponse`: `next_token`

## Wire compatibility

The wire encoding is not changed by adding `optional` to scalar and message fields.
Existing clients and servers that treat default values as absent are not affected.