### PR TITLE
feat: add extensible QueryLedgerState RPC with stake pool distribution

### DIFF
--- a/proto/utxorpc/v1beta/cardano/cardano.proto
+++ b/proto/utxorpc/v1beta/cardano/cardano.proto
@@ -547,14 +547,14 @@ message UpdateDRepCert {
 // added later without changing the chain-agnostic QueryService surface.
 
 // Envelope of a Cardano ledger-state query.
-message LedgerStateQuery {
+message StateQuery {
   oneof query {
     GetStakePoolDistribution stake_pool_distribution = 1; // Active stake distribution across pools.
   }
 }
 
 // Envelope of a Cardano ledger-state query result.
-message LedgerStateQueryResult {
+message StateResult {
   oneof result {
     StakePoolDistribution stake_pool_distribution = 1; // Result of a stake pool distribution query.
   }

--- a/proto/utxorpc/v1beta/cardano/cardano.proto
+++ b/proto/utxorpc/v1beta/cardano/cardano.proto
@@ -554,7 +554,7 @@ message StateQuery {
 }
 
 // Envelope of a Cardano ledger-state query result.
-message StateResult {
+message StateData {
   oneof result {
     StakePoolDistribution stake_pool_distribution = 1; // Result of a stake pool distribution query.
   }

--- a/proto/utxorpc/v1beta/cardano/cardano.proto
+++ b/proto/utxorpc/v1beta/cardano/cardano.proto
@@ -539,6 +539,46 @@ message UpdateDRepCert {
   Anchor anchor = 2;
 }
 
+// LEDGER-STATE QUERIES
+// ====================
+//
+// Cardano-specific queries that mirror the Ouroboros node-to-client
+// LocalStateQuery mini-protocol. The oneof envelope lets new queries be
+// added later without changing the chain-agnostic QueryService surface.
+
+// Envelope of a Cardano ledger-state query.
+message LedgerStateQuery {
+  oneof query {
+    GetStakePoolDistribution stake_pool_distribution = 1; // Active stake distribution across pools.
+  }
+}
+
+// Envelope of a Cardano ledger-state query result.
+message LedgerStateQueryResult {
+  oneof result {
+    StakePoolDistribution stake_pool_distribution = 1; // Result of a stake pool distribution query.
+  }
+}
+
+// Stake pool distribution query. Mirrors Ouroboros GetPoolDistr / GetFilteredPoolDistr.
+message GetStakePoolDistribution {
+  // If non-empty, restrict the result to the listed pool key hashes.
+  // If empty, return the distribution for every pool.
+  repeated bytes pool_keyhashes = 1;
+}
+
+// Per-pool stake share. Mirrors Ouroboros IndividualPoolStake.
+message PoolStakeShare {
+  bytes pool_keyhash = 1; // Pool key hash (pool id).
+  RationalNumber stake_fraction = 2; // Fraction of total active stake delegated to this pool.
+  bytes vrf_keyhash = 3; // Pool's VRF key hash, as reported by the node.
+}
+
+// Result of a stake pool distribution query.
+message StakePoolDistribution {
+  repeated PoolStakeShare pools = 1; // One entry per pool present in the snapshot.
+}
+
 // PATTERN MATCHING
 // ================
 

--- a/proto/utxorpc/v1beta/query/query.proto
+++ b/proto/utxorpc/v1beta/query/query.proto
@@ -87,13 +87,13 @@ message AnyChainLedgerQueryResult {
 }
 
 // Request to run a chain-specific ledger-state query against the current ledger snapshot.
-message QueryLedgerStateRequest {
+message ReadStateRequest {
   AnyChainLedgerQuery query = 1; // The chain-specific query to evaluate.
   google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
 }
 
 // Response carrying the ledger-state query result.
-message QueryLedgerStateResponse {
+message ReadStateResponse {
   AnyChainLedgerQueryResult result = 1; // The query result.
   ChainPoint ledger_tip = 2; // Chain point representing the snapshot the query was evaluated against.
 }
@@ -201,7 +201,7 @@ service QueryService {
   rpc ReadTx(ReadTxRequest) returns (ReadTxResponse); // Get Txs by chain-specific criteria.
   rpc ReadGenesis(ReadGenesisRequest) returns (ReadGenesisResponse); // Get the genesis configuration
   rpc ReadEraSummary(ReadEraSummaryRequest) returns (ReadEraSummaryResponse); // Get the chain era summary
-  rpc QueryLedgerState(QueryLedgerStateRequest) returns (QueryLedgerStateResponse); // Run a chain-specific ledger-state query (e.g. stake pool distribution).
+  rpc ReadState(ReadStateRequest) returns (ReadStateResponse); // Run a chain-specific ledger-state query (e.g. stake pool distribution).
 
   // TODO: decide if we want to expand the scope
   // rpc DumpUtxos(ReadUtxosRequest) returns (stream ReadUtxosResponse); // Dump all available utxos

--- a/proto/utxorpc/v1beta/query/query.proto
+++ b/proto/utxorpc/v1beta/query/query.proto
@@ -72,6 +72,32 @@ message ReadParamsResponse {
   ChainPoint ledger_tip = 2; // The chain point that represent the ledger current position.
 }
 
+// An envelope that wraps a chain-specific ledger-state query.
+message AnyChainLedgerQuery {
+  oneof query {
+    utxorpc.v1beta.cardano.LedgerStateQuery cardano = 1; // A Cardano ledger-state query.
+  }
+}
+
+// An envelope that wraps a chain-specific ledger-state query result.
+message AnyChainLedgerQueryResult {
+  oneof result {
+    utxorpc.v1beta.cardano.LedgerStateQueryResult cardano = 1; // A Cardano ledger-state query result.
+  }
+}
+
+// Request to run a chain-specific ledger-state query against the current ledger snapshot.
+message QueryLedgerStateRequest {
+  AnyChainLedgerQuery query = 1; // The chain-specific query to evaluate.
+  google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
+}
+
+// Response carrying the ledger-state query result.
+message QueryLedgerStateResponse {
+  AnyChainLedgerQueryResult result = 1; // The query result.
+  ChainPoint ledger_tip = 2; // Chain point representing the snapshot the query was evaluated against.
+}
+
 // An evenlope that holds an UTxO patterns from any of compatible chains
 message AnyUtxoPattern {
   oneof utxo_pattern {
@@ -175,6 +201,7 @@ service QueryService {
   rpc ReadTx(ReadTxRequest) returns (ReadTxResponse); // Get Txs by chain-specific criteria.
   rpc ReadGenesis(ReadGenesisRequest) returns (ReadGenesisResponse); // Get the genesis configuration
   rpc ReadEraSummary(ReadEraSummaryRequest) returns (ReadEraSummaryResponse); // Get the chain era summary
+  rpc QueryLedgerState(QueryLedgerStateRequest) returns (QueryLedgerStateResponse); // Run a chain-specific ledger-state query (e.g. stake pool distribution).
 
   // TODO: decide if we want to expand the scope
   // rpc DumpUtxos(ReadUtxosRequest) returns (stream ReadUtxosResponse); // Dump all available utxos

--- a/proto/utxorpc/v1beta/query/query.proto
+++ b/proto/utxorpc/v1beta/query/query.proto
@@ -80,9 +80,9 @@ message AnyChainStateQuery {
 }
 
 // An envelope that wraps a chain-specific ledger-state query result.
-message AnyChainStateResult {
+message AnyChainStateData {
   oneof result {
-    utxorpc.v1beta.cardano.StateResult cardano = 1; // A Cardano ledger-state query result.
+    utxorpc.v1beta.cardano.StateData cardano = 1; // A Cardano ledger-state query result.
   }
 }
 
@@ -94,7 +94,7 @@ message ReadStateRequest {
 
 // Response carrying the ledger-state query result.
 message ReadStateResponse {
-  AnyChainStateResult result = 1; // The query result.
+  AnyChainStateData result = 1; // The query result.
   ChainPoint ledger_tip = 2; // Chain point representing the snapshot the query was evaluated against.
 }
 

--- a/proto/utxorpc/v1beta/query/query.proto
+++ b/proto/utxorpc/v1beta/query/query.proto
@@ -73,28 +73,28 @@ message ReadParamsResponse {
 }
 
 // An envelope that wraps a chain-specific ledger-state query.
-message AnyChainLedgerQuery {
+message AnyChainStateQuery {
   oneof query {
-    utxorpc.v1beta.cardano.LedgerStateQuery cardano = 1; // A Cardano ledger-state query.
+    utxorpc.v1beta.cardano.StateQuery cardano = 1; // A Cardano ledger-state query.
   }
 }
 
 // An envelope that wraps a chain-specific ledger-state query result.
-message AnyChainLedgerQueryResult {
+message AnyChainStateResult {
   oneof result {
-    utxorpc.v1beta.cardano.LedgerStateQueryResult cardano = 1; // A Cardano ledger-state query result.
+    utxorpc.v1beta.cardano.StateResult cardano = 1; // A Cardano ledger-state query result.
   }
 }
 
 // Request to run a chain-specific ledger-state query against the current ledger snapshot.
 message ReadStateRequest {
-  AnyChainLedgerQuery query = 1; // The chain-specific query to evaluate.
+  AnyChainStateQuery query = 1; // The chain-specific query to evaluate.
   google.protobuf.FieldMask field_mask = 2; // Field mask to selectively return fields.
 }
 
 // Response carrying the ledger-state query result.
 message ReadStateResponse {
-  AnyChainLedgerQueryResult result = 1; // The query result.
+  AnyChainStateResult result = 1; // The query result.
   ChainPoint ledger_tip = 2; // Chain point representing the snapshot the query was evaluated against.
 }
 


### PR DESCRIPTION
## Summary
- Adds a chain-agnostic `QueryLedgerState` RPC to the v1beta `QueryService`, using `AnyChainLedgerQuery` / `AnyChainLedgerQueryResult` envelopes so future queries can be added without changing the service surface.
- On the Cardano side, introduces `LedgerStateQuery` / `LedgerStateQueryResult` `oneof` envelopes that mirror the Ouroboros node-to-client `LocalStateQuery` mini-protocol.
- First concrete query: `GetStakePoolDistribution` (with optional `pool_keyhashes` filter) returning `PoolStakeShare { pool_keyhash, stake_fraction, vrf_keyhash }` — matches Ouroboros `GetPoolDistr` / `IndividualPoolStake`.
- Changes are scoped to v1beta only; v1alpha is intentionally left untouched.

## Why this shape
- `QueryLedgerState` signature stays stable as new ledger-state queries are added — they become new variants on the chain-side `oneof`s, which is non-breaking under proto3.
- Envelope pattern matches the existing `AnyChainParams`, `AnyChainBlock`, `AnyUtxoData` convention.
- Response carries `ledger_tip` (consistent with `ReadParamsResponse` / `ReadUtxosResponse`) since a point-in-time query is only meaningful with its snapshot's tip.

## Test plan
- [ ] `buf build proto` passes (verified locally).
- [ ] CI codegen workflows succeed across Rust / Go / Node / .NET / Python / Haskell / docs.
- [ ] Spot-check generated Rust under `gen/rust/` once CI publishes: `QueryLedgerState` is exposed on the `QueryService` client/server traits and the `oneof` envelopes round-trip.
- [ ] Manual review that no v1alpha files were modified.

## Follow-ups (not in this PR)
- Wire additional Ouroboros queries (`GetStakePoolParams`, `GetStakeSnapshots`, `GetEpochNo`, `GetCurrentEra`, `GetRewardInfoPools`) as new `LedgerStateQuery` / `LedgerStateQueryResult` variants.
- Decide whether to mirror this addition into v1alpha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)