### PR TITLE
feat(v1beta): add original_cbor field to Cardano TxOutput

### DIFF
--- a/proto/utxorpc/v1beta/cardano/cardano.proto
+++ b/proto/utxorpc/v1beta/cardano/cardano.proto
@@ -37,6 +37,7 @@ message TxOutput {
   repeated Multiasset assets = 3; // Additional native (non-ADA) assets in the output.
   optional Datum datum = 4; // Plutus data associated with the output.
   optional Script script = 5; // Script associated with the output.
+  optional bytes original_cbor = 6; // Original cbor-encoded output as seen on-chain.
 }
 
 message Datum {


### PR DESCRIPTION
## Summary
- Adds an optional `original_cbor` field to `TxOutput` in the v1beta Cardano proto, mirroring the existing field on `Datum`.
- Lets consumers access the on-chain CBOR encoding of a transaction output without needing to re-encode from the parsed representation.

## Test plan
- [ ] CI regenerates Go/Rust/dotnet bindings cleanly
- [ ] Field number `6` is unused on `TxOutput` (confirmed — previous max was `5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)