### PR TITLE
feat(cardano): Make optional fields in EvalReport optional

### DIFF
--- a/proto/utxorpc/v1beta/cardano/cardano.proto
+++ b/proto/utxorpc/v1beta/cardano/cardano.proto
@@ -731,21 +731,21 @@ message EraSummaries {
 // EVALUATION
 // ==========
 
-// A single evaluation report entry, used for both script errors and execution
-// traces. The purpose and index fields identify which redeemer produced the
-// entry, allowing the client to correlate errors and traces with specific
-// script executions.
+// A single evaluation report entry, used for script errors, execution traces,
+// and transaction-level evaluation errors (e.g. balance mismatches). When the
+// entry relates to a specific redeemer, purpose and index identify which one;
+// for transaction-level errors these fields are absent.
 message EvalReport {
   string msg = 1; // Human-readable message.
-  RedeemerPurpose purpose = 2; // Purpose of the redeemer that produced this entry.
-  uint32 index = 3; // 0-based index of the redeemer within its purpose.
+  optional RedeemerPurpose purpose = 2; // Purpose of the redeemer that produced this entry.
+  optional uint32 index = 3; // 0-based index of the redeemer within its purpose.
 }
 
 // Result of evaluating a transaction against the current ledger state.
 message TxEval {
   BigInt fee = 1; // Computed minimum fee for the transaction.
   ExUnits ex_units = 2; // Total execution units consumed across all redeemers.
-  repeated EvalReport errors = 3; // Per-redeemer script execution errors.
+  repeated EvalReport errors = 3; // Script execution and transaction-level evaluation errors.
   repeated EvalReport traces = 4; // Per-redeemer script execution traces.
   repeated Redeemer redeemers = 5; // Redeemers with evaluated execution units.
 }


### PR DESCRIPTION
## Summary

`EvalReport` (added in #202) always requires `purpose` and `index`, but not every evaluation error relates to a specific redeemer - transaction-level errors such as balance mismatches have no redeemer to point at.

This PR marks `purpose` and `index` as `optional` in proto3 so they can be absent when the error is transaction-level rather than redeemer-specific.

### What changed

- `EvalReport.purpose` and `EvalReport.index` are now `optional`
- Updated inline docs to explain when the fields are present vs absent
- Comment on `TxEval.errors` broadened to cover transaction-level errors