### PR TITLE
ci: use npm trusted publishing for node package

### DIFF
--- a/.github/actions/publish-node/action.yml
+++ b/.github/actions/publish-node/action.yml
@@ -1,9 +1,6 @@
 name: 'publish node'
 description: 'Transpiles and publishes the Node package from the codegen artifact'
 inputs:
-  registry-token:
-    description: token to authenticate to npmjs.org
-    required: false
   mode:
     description: supported values are 'release' and 'dry-run'
     required: true
@@ -11,11 +8,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  
+
     - name: Setup npm
       uses: actions/setup-node@v4
       with:
-        node-version: 20.11.0
+        # Node 24.5.0 bundles npm 11.5.1, the minimum required for
+        # OIDC trusted publishing.
+        node-version: 24.5.0
         cache: "npm"
         cache-dependency-path: "codegen/node/package.json"
         registry-url: 'https://registry.npmjs.org'
@@ -34,11 +33,11 @@ runs:
       run: |
         npm publish --dry-run
     
+    # Authentication is handled via OIDC trusted publishing; no token
+    # is needed. Requires `id-token: write` permission on the calling job.
     - name: Publish to npm
       if: inputs.mode == 'release'
       working-directory: codegen/node
       shell: bash
-      env:
-        NODE_AUTH_TOKEN: ${{ inputs.registry-token }}
       run: |
         npm publish --access public

--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -46,6 +46,11 @@ jobs:
   publish-node:
     runs-on: ubuntu-latest
 
+    # Required for npm trusted publishing (OIDC).
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,7 +62,6 @@ jobs:
 
       - uses: ./.github/actions/publish-node
         with:
-          registry-token: ${{ secrets.NPM_REGISTRY_TOKEN }}
           mode: ${{ inputs.mode }}
 
   publish-go:


### PR DESCRIPTION
## Context

The last release failed because the npm publish step used a token that had expired. A **trusted publisher** has now been enabled for this repo on npmjs.com, so we can switch to OIDC-based publishing and drop the token entirely.

## Changes

`.github/actions/publish-node/action.yml`
- Removed the `registry-token` input and `NODE_AUTH_TOKEN` env var — publish now authenticates via OIDC.
- Bumped Node `20.11.0` → `24.5.0`, which bundles npm 11.5.1 (the minimum version required for trusted publishing). This is the publish toolchain only, not the library's runtime target.

`.github/workflows/publish-all.yml`
- Added `permissions: { id-token: write, contents: read }` to the `publish-node` job (OIDC requires `id-token: write`).
- Dropped the `NPM_REGISTRY_TOKEN` secret input.

## Follow-ups / verify

- The npm trusted publisher matches against the **caller** workflow with reusable workflows — confirm it points at `release.yml`.
- The `NPM_REGISTRY_TOKEN` secret can be deleted once this is confirmed working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)