### PR TITLE
ci(spec): remove obsolete gen/node/.npmrc (trusted publishing)

### DIFF
--- a/gen/node/.npmrc
+++ b/gen/node/.npmrc
@@ -1,4 +1,0 @@
-registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
-
-@utxorpc:registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Context

Follow-up to #204. That PR moved the node package to OIDC trusted publishing and removed `NODE_AUTH_TOKEN` from the workflow, but `gen/node/.npmrc` (added in #61 for the old token flow) was left behind.

With `NODE_AUTH_TOKEN` now unset, its `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` line injects an **empty** token that overrides the OIDC credential — publish fails with a masked `404`. This was reproduced locally and is the latent CI failure #204 didn't fully resolve.

## Change

`git rm gen/node/.npmrc`. All three lines are now either redundant or harmful:
- `registry=` / `@utxorpc:registry=` — only restate npm defaults.
- `_authToken=${NODE_AUTH_TOKEN}` — breaks OIDC auth.

Trusted publishing needs no `.npmrc` (npm ≥ 11.5.1 handles auth via OIDC). npm never includes `.npmrc` in the published tarball, so **no effect on consumers**.

Refs #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)