### PR TITLE
fix(python): require protobuf >=7.34.1 to match generated gencode

### DIFF
--- a/gen/python/pyproject.toml
+++ b/gen/python/pyproject.toml
@@ -16,7 +16,7 @@ include = ["utxorpc_spec/**/*.py", "utxorpc_spec/**/*.pyi"]
 [tool.poetry.dependencies] # https://python-poetry.org/docs/dependency-specification/
 python = ">=3.9,<4.0"
 grpcio = ">=1.74,<2"
-protobuf = ">=6.32,<7"
+protobuf = ">=7.34.1,<8"
 grpc-stubs = "^1.53.0.6"
 
 [[tool.poetry.source]]


### PR DESCRIPTION
## Problem

The published `utxorpc-spec` 0.19.0 package is internally inconsistent:

- Its generated `_pb2.py` files are stamped with protobuf **gencode 7.34.1**.
- `gen/python/pyproject.toml` declared `protobuf = ">=6.32,<7"`.

Protobuf requires the runtime version to be **no older than the linked gencode version**, so:

```
google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf
Gencode/Runtime versions ... gencode 7.34.1 runtime 6.33.6
```

With the `<7` cap, no protobuf version satisfies both the package metadata and its own generated code. This blocks every downstream SDK — see [python-sdk#9](https://github.com/utxorpc/python-sdk/pull/9), which cannot resolve dependencies against `utxorpc-spec` 0.19.0.

## Fix

Align the `protobuf` bound with the generated gencode: `>=7.34.1,<8`.

## Follow-up

This needs a new `utxorpc-spec` release published to PyPI before python-sdk#9 can go green (0.19.0 is already published and immutable).