### PR TITLE
fix(python): rewrite generated imports with protoletariat

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -70,10 +70,26 @@ jobs:
       - name: Generate dotnet v1beta
         run: buf generate --template buf.gen.dotnet.v1beta.yaml
 
+      # The protobuf Python plugin emits absolute imports rooted at the proto
+      # package (e.g. `from utxorpc.v1alpha...`), which do not resolve once the
+      # code is packaged under `utxorpc_spec`. protoletariat rewrites the
+      # proto-generated imports to relative imports so the single utxorpc-spec
+      # package works regardless of where it is mounted.
       - name: Fix python imports
-        run:
-          find gen/python/utxorpc_spec -type f -exec sed -i '' 's@from
-          utxorpc@from utxorpc_spec.utxorpc@g' {} \;
+        run: |
+          pipx install protoletariat
+          protol \
+            --create-package \
+            --in-place \
+            --exclude-google-imports \
+            --python-out gen/python/utxorpc_spec \
+            buf proto
+
+      - name: Smoke-test python imports
+        run: |
+          pip install --quiet protobuf grpcio
+          cd gen/python
+          python -c "import utxorpc_spec.utxorpc.v1alpha.sync.sync_pb2, utxorpc_spec.utxorpc.v1beta.sync.sync_pb2; print('python import OK')"
 
       - name: Create codegen artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem

The protobuf Python plugin emits absolute imports rooted at the proto package:

```python
from utxorpc.v1alpha.cardano import cardano_pb2
```

These do not resolve once the code is packaged under `utxorpc_spec` (modules install as `utxorpc_spec.utxorpc.*`), so `import utxorpc_spec...` fails with `ModuleNotFoundError: No module named 'utxorpc.v1alpha'` — `utxorpc-spec` 0.19.x is un-importable.

`generate.yml` already had a `Fix python imports` step, but it used BSD `sed -i ''` syntax which is invalid on the GNU/Linux runner — it silently never applied.

## Fix

Replace the sed hack with [protoletariat](https://github.com/cpcloud/protoletariat), which rewrites proto-generated imports to **relative** imports by inspecting the FileDescriptorSet — location-independent and correct for both `v1alpha` and `v1beta`. `--exclude-google-imports` leaves the well-known-type imports alone.

Also adds an **import smoke-test** (v1alpha + v1beta) so an un-importable package can't ship silently again.

## Follow-up

Needs a new `spec` release (v0.19.2) to republish a working `utxorpc-spec`; then python-sdk#9 bumps to it.