### PR TITLE
ci: grant id-token to the PR dry-run job

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,6 +22,12 @@ jobs:
   publish-dry-run:
     name: "Validate Package Publishing"
     needs: [codegen]
+    # publish-all's publish-node job needs id-token: write for npm trusted
+    # publishing. A called workflow cannot request more than its caller grants,
+    # and this workflow is capped at contents: read above, so grant it here.
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/publish-all.yml
     secrets: inherit
     with:


### PR DESCRIPTION
`pr-check.yml` has failed at **startup on every pull request since 2026-05-19**. The last run that actually executed was 2026-05-13 — every PR merged since then landed without codegen or packaging validation.

## Cause

#204 added `permissions: id-token: write` to `publish-all.yml`'s `publish-node` job for npm trusted publishing. A reusable workflow cannot request more permission than its caller grants, and `pr-check.yml:14-15` caps the whole workflow at `contents: read`. The call is rejected before any job starts, so the run reports `startup_failure` in ~1s with no logs.

`release.yml` and `dry-run.yml` declare no top-level `permissions` block, so they inherit the repository default and were unaffected. That's why releases kept publishing normally while PR validation was silently dead — the breakage left no trace anywhere anyone was looking.

## Fix

Grant `id-token: write` on the `publish-dry-run` job rather than workflow-wide, so the `codegen` job keeps the narrower `contents: read`.

## Verifying

This PR is its own test: if `pr-check.yml` starts and the six dry-run publish jobs report, the fix works. For `pull_request` events the workflow definition comes from the PR head, so no merge is needed to see it take effect.

Worth noting the runs that do start may still fail on their own merits — the last executing run (2026-05-13) was itself a `failure`. Getting past `startup_failure` is the goal here; anything it surfaces afterward is a separate finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
