### PR TITLE
ci: stop contacting live registries in publish dry-runs

### DIFF
--- a/.github/actions/publish-haskell/action.yml
+++ b/.github/actions/publish-haskell/action.yml
@@ -83,14 +83,13 @@ runs:
       working-directory: codegen/haskell
       run: stack haddock --haddock-for-hackage
 
-    - name: Upload candidate to Hackage
-      if: inputs.mode == 'dry-run'
-      shell: bash
-      working-directory: codegen/haskell
-      run: |
-        export HACKAGE_KEY=${{ inputs.registry-token }}
-        stack upload --candidate --test-tarball .
-        stack upload --candidate -d .
+    # dry-run validates locally only. The steps above already run `stack test`,
+    # `stack sdist` and `stack haddock --haddock-for-hackage`, which is every
+    # check a pull request needs. Uploading a candidate here was not a
+    # simulation: it pushed a real candidate release to Hackage from unreviewed
+    # code, and it fails outright once the version in the cabal file has been
+    # published, because the docs upload targets a candidate that no longer
+    # exists and returns 404.
 
     - name: Upload to Hackage
       if: inputs.mode == 'release' && startsWith(github.ref, 'refs/tags/v')

--- a/.github/actions/publish-node/action.yml
+++ b/.github/actions/publish-node/action.yml
@@ -26,12 +26,16 @@ runs:
         npm install
         npm run build
 
-    - name: Publish dry run
+    # `npm publish --dry-run` still asks the registry whether the version
+    # already exists, so it can only pass in the window between a version bump
+    # and the release that publishes it. `npm pack` performs the same packing
+    # and manifest validation without contacting the registry.
+    - name: Validate package
       if: inputs.mode == 'dry-run'
       working-directory: codegen/node
       shell: bash
       run: |
-        npm publish --dry-run
+        npm pack --dry-run
     
     # Authentication is handled via OIDC trusted publishing; no token
     # is needed. Requires `id-token: write` permission on the calling job.

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,6 +22,12 @@ jobs:
   publish-dry-run:
     name: "Validate Package Publishing"
     needs: [codegen]
+    # publish-all's publish-node job needs id-token: write for npm trusted
+    # publishing. A called workflow cannot request more than its caller grants,
+    # and this workflow is capped at contents: read above, so grant it here.
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/publish-all.yml
     secrets: inherit
     with:


### PR DESCRIPTION
`publish-node` and `publish-haskell` fail on **every** pull request. They are the only two publish jobs whose dry-run mode contacts a live package registry; rust, python, go and dotnet validate locally and pass.

This is independent of #209 and #210 — it reproduces on #210, which contains nothing but a one-line workflow permissions change.

## node

`npm publish --dry-run` still asks the registry whether the version exists:

```
npm error You cannot publish over the previously published versions: 0.19.2.
```

The version in `gen/node/package.json` only changes at release time, so it matches what is already on npm for all but a brief window after each bump.

npm 10 never made that request. Verified directly:

```
$ npx npm@10 publish --dry-run   # @utxorpc/spec 0.19.2
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)   → exit 0

$ npx npm@11 publish --dry-run   # identical package.json
npm error You cannot publish over the previously published versions: 0.19.2.  → exit 1
```

#204 moved this job from `node-version: 20.11.0` to `24.5.0` for trusted publishing — npm 10.2.4 to npm 11.5.1. The command was never touched; its behaviour changed underneath it. Because that same PR also broke `pr-check.yml` at startup (#210), the job never ran on a pull request again and the regression stayed invisible.

`npm pack --dry-run` does the same packing and manifest validation without the registry round-trip.

## haskell

`stack upload --candidate` is not a simulation — it **pushes a real candidate release to Hackage from unreviewed pull request code**. Beyond being wrong on its own terms, it fails:

```
Error: [S-2804] forbidden upload
       Usually means: you've already uploaded this package/version combination.
       Ignoring error and continuing.
       Package name and version already exist in the database
Error: [S-6108] unhandled status code: 404
       Upload failed on utxorpc-0.0.19.2-docs.tar.gz
```

Note stack **ignores** the rejected tarball upload. The fatal error is the second command, `stack upload --candidate -d .`, which posts haddocks to the candidate URL. Hackage currently has candidates only up to `0.0.18.1`; there is none for any `0.0.19.x`:

```
/package/utxorpc-0.0.18.1/candidate → 200
/package/utxorpc-0.0.19.0/candidate → 404
/package/utxorpc-0.0.19.2/candidate → 404
```

So the docs upload has no candidate to attach to and 404s. This job last passed on 2026-05-01 at 12:35 UTC; the cabal version moved to `0.0.19.0` at 16:17 UTC that day and Hackage published it at 16:30 UTC. The next pull request, 2026-05-05, failed on `publish-haskell` alone — and every one since.

The preceding steps already run `stack test`, `stack sdist` and `stack haddock --haddock-for-hackage`, which is every check a pull request needs, so the candidate upload is dropped rather than replaced.

## Scope

Releases are untouched. Both real uploads live in the `release` branches of these actions:

- node: `npm publish --access public` under `inputs.mode == 'release'`
- haskell: `stack upload --test-tarball .` under `inputs.mode == 'release' && startsWith(github.ref, 'refs/tags/v')`

The only behaviour lost is the candidate upload that ran during `release.yml`'s pre-flight dry-run stage, which the real upload immediately superseded.

## Verifying

This PR is its own test — `publish-node` and `publish-haskell` should both go green, which no pull request has managed since 2026-05-01. Requires #210 to be on the branch or merged first, otherwise `pr-check.yml` never starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
